### PR TITLE
Add set_rich_presence

### DIFF
--- a/src/friends.rs
+++ b/src/friends.rs
@@ -115,6 +115,22 @@ impl <Manager> Friends<Manager> {
             sys::SteamAPI_ISteamFriends_ActivateGameOverlayInviteDialog(self.friends, lobby.0);
         }
     }
+    
+    /// Set rich presence for the user. Unsets the rich presence if `value` is None or empty.
+    /// See [Steam API](https://partner.steamgames.com/doc/api/ISteamFriends#SetRichPresence)
+    pub fn set_rich_presence(&self, key: &str, value: Option<&str>) -> bool {
+        unsafe {
+            let key = CString::new(key).unwrap_or_default();
+            sys::SteamAPI_ISteamFriends_SetRichPresence(
+                self.friends,
+                key.as_ptr() as *const _,
+                value
+                    .and_then(|v| CString::new(v).ok())
+                    .map(|s| s.as_ptr() as *const _)
+                    .unwrap_or(std::ptr::null()),
+            )
+        }
+    }
 }
 
 /// Information about a friend's current state in a game


### PR DESCRIPTION
Adding `set_rich_presence` function, initially [here](https://partner.steamgames.com/doc/api/ISteamFriends#SetRichPresence).

This is a pretty straightforward function that receives two strings and returns a boolean.

Tested by calling this function and getting a `true` response, though to be honest this wasn't reflected on the [test URL](https://steamcommunity.com/dev/testrichpresence).