### PR TITLE
[wip] Support newer Steam networking interfaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,10 @@ mod matchmaking;
 pub use crate::matchmaking::*;
 mod networking;
 pub use crate::networking::*;
+mod networking_messages;
+pub use crate::networking_messages::*;
+mod networking_types;
+pub use crate::networking_types::*;
 mod user;
 pub use crate::user::*;
 mod user_stats;
@@ -330,6 +334,17 @@ impl <Manager> Client<Manager> {
             UGC {
                 ugc,
                 inner: self.inner.clone(),
+            }
+        }
+    }
+
+    pub fn networking_messages(&self) -> NetworkingMessages<Manager> {
+        unsafe {
+            let net = sys::SteamAPI_SteamNetworkingMessages_SteamAPI_v002();
+            debug_assert!(!net.is_null());
+            NetworkingMessages {
+                net,
+                _inner: self.inner.clone(),
             }
         }
     }

--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -1,0 +1,50 @@
+use super::*;
+use sys::{EResult, SteamNetworkingIdentity};
+
+/// Access to the steam networking messages interface
+pub struct NetworkingMessages<Manager> {
+    pub(crate) net: *mut sys::ISteamNetworkingMessages,
+    pub(crate) _inner: Arc<Inner<Manager>>,
+}
+
+impl<Manager> NetworkingMessages<Manager> {
+    pub fn accept_p2p_session(&self, user: SteamNetworkingIdentity) -> bool {
+        unsafe {
+            sys::SteamAPI_ISteamNetworkingMessages_AcceptSessionWithUser(
+                self.net,
+                &user as *const _,
+            )
+        }
+    }
+
+    pub fn close_p2p_session(&self, user: SteamNetworkingIdentity) -> bool {
+        unsafe {
+            sys::SteamAPI_ISteamNetworkingMessages_CloseSessionWithUser(self.net, &user as *const _)
+        }
+    }
+
+    pub fn send_message_to_user(
+        &self,
+        user: SteamNetworkingIdentity,
+        send_type: SendFlags,
+        data: &[u8],
+        channel: u32,
+    ) -> Result<(), SteamError> {
+        let result = unsafe {
+            sys::SteamAPI_ISteamNetworkingMessages_SendMessageToUser(
+                self.net,
+                &user as *const _,
+                data.as_ptr() as _,
+                data.len() as u32,
+                send_type.bits(),
+                channel as i32,
+            )
+        };
+
+        if result == EResult::k_EResultOK {
+            return Ok(());
+        }
+
+        return Err(result.into());
+    }
+}

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1,0 +1,75 @@
+use crate::SteamId;
+use std::ffi::CStr;
+use std::net::IpAddr;
+
+bitflags! {
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[repr(C)]
+    pub struct SendFlags: i32 {
+        const UNRELIABLE = sys::k_nSteamNetworkingSend_Unreliable;
+        const NO_NAGLE = sys::k_nSteamNetworkingSend_NoNagle;
+        const UNRELIABLE_NO_NAGLE = sys::k_nSteamNetworkingSend_UnreliableNoNagle;
+        const NO_DELAY = sys::k_nSteamNetworkingSend_NoDelay;
+        const UNRELIABLE_NO_DELAY = sys::k_nSteamNetworkingSend_UnreliableNoDelay;
+        const RELIABLE = sys::k_nSteamNetworkingSend_Reliable;
+        const RELIABLE_NO_NAGLE = sys::k_nSteamNetworkingSend_ReliableNoNagle;
+        const USE_CURRENT_THREAD = sys::k_nSteamNetworkingSend_UseCurrentThread;
+        const AUTO_RESTART_BROKEN_SESSION = sys::k_nSteamNetworkingSend_AutoRestartBrokenSession;
+    }
+}
+
+pub enum NetworkingIdentity<'a> {
+    IpAddress(IpAddr, u16),
+    Generic(&'a CStr),
+    SteamId(SteamId),
+}
+
+impl From<SteamId> for NetworkingIdentity<'_> {
+    fn from(id: SteamId) -> Self {
+        NetworkingIdentity::SteamId(id)
+    }
+}
+
+pub struct NetworkingMessage {
+    inner: *mut sys::SteamNetworkingMessage_t,
+}
+
+impl NetworkingMessage {
+    pub fn sender_id(&self) -> NetworkingIdentity {
+        use sys::ESteamNetworkingIdentityType::*;
+
+        unsafe {
+            let ident = &mut (*self.inner).m_identityPeer;
+
+            match ident.m_eType {
+                k_ESteamNetworkingIdentityType_SteamID => {
+                    NetworkingIdentity::SteamId(SteamId::from_raw(ident.GetSteamID64()))
+                }
+                k_ESteamNetworkingIdentityType_IPAddress => {
+                    let addr = &(*sys::SteamAPI_SteamNetworkingIdentity_GetIPAddr(ident as *mut _));
+                    let ip_bytes = addr.__bindgen_anon_1.m_ipv6;
+
+                    NetworkingIdentity::IpAddress(IpAddr::from(ip_bytes), (*addr).m_port)
+                }
+                k_ESteamNetworkingIdentityType_GenericString => {
+                    NetworkingIdentity::Generic(CStr::from_ptr(ident.GetGenericString()))
+                }
+                _ => unimplemented!("TODO: must be a steamworks bug"),
+            }
+        }
+    }
+
+    pub fn data(&self) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts((*self.inner).m_pData as _, (*self.inner).m_cbSize as usize)
+        }
+    }
+}
+
+impl Drop for NetworkingMessage {
+    fn drop(&mut self) {
+        debug_assert!(!self.inner.is_null());
+
+        unsafe { sys::SteamAPI_SteamNetworkingMessage_t_Release(self.inner) }
+    }
+}


### PR DESCRIPTION
Starting with `SteamNetworkingMessages` initially which has a much smaller API surface and is almost completely compatible with the message based API in `SteamNetworking`. I've opened this PR as a draft for any early feedback on the Rust wrapping, but there's still a lot to do.