### PR TITLE
Fix unaligned reference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,9 @@ impl <M> SingleClient<M> where M: Manager {
                         apicall_result.as_mut_ptr() as *mut _, apicall.m_cubParam as _,
                         apicall.m_iCallback, &mut failed
                     ) {
-                        if let Some(cb) = callbacks.call_results.remove(&apicall.m_hAsyncCall) {
+                        // The &{val} pattern here is to avoid taking a reference to a packed field
+                        // Since the value here is Copy, we can just copy it and borrow the copy
+                        if let Some(cb) = callbacks.call_results.remove(&{apicall.m_hAsyncCall}) {
                             cb(apicall_result.as_mut_ptr() as *mut _, failed);
                         }
                     }


### PR DESCRIPTION
As described in [the tracking issue](https://github.com/rust-lang/rust/issues/82523), taking a reference to a field in a packed struct can cause UB.  Copying the field's value when possible is preferred.