### PR TITLE
Added Eq and Copy to the auth handle

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -140,6 +140,7 @@ fn test() {
 
 /// A handle for an authentication ticket that can be used to cancel
 /// it.
+#[derive(Eq, PartialEq, Copy, Clone)]
 pub struct AuthTicket(pub(crate) sys::HAuthTicket);
 
 /// Called when generating a authentication session ticket.


### PR DESCRIPTION
I pretty much needed that for my project; furthermore, comparing handles and being able to move them out (since they're really just an u32) seemed quite a reasonably nice to have. 