### PR TITLE
Add `raw-bindings` feature which exports `sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ features = [ "docs-only" ]
 
 [features]
 default = []
+raw-bindings = []
 # Skip looking for the steamworks sdk for docs builds
 docs-only = ["steamworks-sys/docs-only"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,14 @@
-extern crate steamworks_sys as sys;
 #[macro_use]
 extern crate thiserror;
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
 extern crate lazy_static;
+
+#[cfg(feature = "raw-bindings")]
+pub use steamworks_sys as sys;
+#[cfg(not(feature = "raw-bindings"))]
+use steamworks_sys as sys;
 
 mod error;
 pub use crate::error::*;


### PR DESCRIPTION
I have found myself needing this on multiple occasions and it's nice that steamworks-rs already has all the bindings generated for us.