### PR TITLE
Make networking_types::MessageNumber more convenient to use

### DIFF
--- a/src/networking_sockets.rs
+++ b/src/networking_sockets.rs
@@ -378,7 +378,7 @@ impl<Manager: 'static> ListenSocket<Manager> {
                 .into_iter()
                 .map(|x| {
                     if x >= 0 {
-                        Ok(MessageNumber(x))
+                        Ok(MessageNumber(x as u64))
                     } else {
                         Err((-x).try_into().expect("invalid error code"))
                     }
@@ -701,7 +701,7 @@ impl<Manager: 'static> NetConnection<Manager> {
                 &mut out_message_number,
             );
             match result {
-                sys::EResult::k_EResultOK => Ok(MessageNumber(out_message_number)),
+                sys::EResult::k_EResultOK => Ok(MessageNumber(out_message_number as u64)),
                 error => Err(error.into()),
             }
         }

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -11,7 +11,7 @@ use std::panic::catch_unwind;
 use std::sync::Arc;
 use steamworks_sys as sys;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MessageNumber(pub(crate) i64);
 

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -13,7 +13,13 @@ use steamworks_sys as sys;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct MessageNumber(pub(crate) i64);
+pub struct MessageNumber(pub(crate) u64);
+
+impl From<MessageNumber> for u64 {
+    fn from(number: MessageNumber) -> Self {
+        number.0
+    }
+}
 
 bitflags! {
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -1589,7 +1595,7 @@ impl<Manager> NetworkingMessage<Manager> {
     /// Message number assigned by the sender.
     /// This is not used for outbound messages
     pub fn message_number(&self) -> MessageNumber {
-        unsafe { MessageNumber((*self.message).m_nMessageNumber) }
+        unsafe { MessageNumber((*self.message).m_nMessageNumber as u64) }
     }
 
     /// Bitmask of k_nSteamNetworkingSend_xxx flags.


### PR DESCRIPTION
I couldn't find anything explicit in the steamworks documentation, so I'm assuming that unreliable messages can also be unordered. This way, it's easy to check which message was received first.