### PR TITLE
Enable formatting checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        toolchain: [stable]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        id: toolchain
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          components: rustfmt, clippy
+          override: true
+
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        if: runner.os == 'linux'
+
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-test-rustc-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - uses: actions-rs/cargo@v1
+        if: runner.os == 'linux'
+        with:
+          command: fmt
+          args: --all -- --check

--- a/examples/chat-example/src/main.rs
+++ b/examples/chat-example/src/main.rs
@@ -1,8 +1,8 @@
-use steamworks::*;
+use clipboard::{ClipboardContext, ClipboardProvider};
 use macroquad::prelude::*;
 use macroquad::ui::*;
 use std::sync::mpsc;
-use clipboard::{ClipboardContext, ClipboardProvider};
+use steamworks::*;
 
 //MAYBE IT'S NOT GOOD GAME ARCHITECTURE
 struct GameState {
@@ -11,7 +11,7 @@ struct GameState {
 
 enum States {
     Menu(MenuState),
-    Chat(ChatState)
+    Chat(ChatState),
 }
 
 struct MenuState {
@@ -51,7 +51,7 @@ async fn main() {
     };
 
     //For getting values from callback
-    let (sender_create_lobby, receiver_create_lobby) =  mpsc::channel();
+    let (sender_create_lobby, receiver_create_lobby) = mpsc::channel();
     let (sender_join_lobby, receiver_join_lobby) = mpsc::channel();
     let (sender_accept, receiver_accept) = mpsc::channel();
 
@@ -73,93 +73,120 @@ async fn main() {
 
         match state.state.as_mut() {
             States::Menu(menu_state) => {
-                widgets::Group::new(hash!(), vec2(800.0, 600.))
-                    .ui(&mut *root_ui(), |ui| {
-                        //Creating lobby by button
-                        if ui.button(vec2(20.0, 40.0), "Create Lobby") {
-                            matchmaking.create_lobby(LobbyType::FriendsOnly, 4, move |lobby| {
-                                match lobby {
-                                    Ok(lobby) => {
-                                        local_sender_create_lobby.send(lobby).unwrap();
-                                    }
-                                    Err(_) => {}
-                                };
-                            });
-                        }
-
-                        //Try to join in lobby with id from InputField
-                        if ui.button(vec2(120.0, 40.0), "Connect") {
-                            let lobby_id: Result<u64, _> = menu_state.lobby_input.parse();
-                            match lobby_id {
-                                Ok(id) => {
-                                    matchmaking.join_lobby(LobbyId::from_raw(id),  move |result| {
-                                        if let Ok(lobby) = result {
-                                            local_sender_join_lobby.send(lobby).unwrap();
-                                        }
-                                    });
+                widgets::Group::new(hash!(), vec2(800.0, 600.)).ui(&mut *root_ui(), |ui| {
+                    //Creating lobby by button
+                    if ui.button(vec2(20.0, 40.0), "Create Lobby") {
+                        matchmaking.create_lobby(LobbyType::FriendsOnly, 4, move |lobby| {
+                            match lobby {
+                                Ok(lobby) => {
+                                    local_sender_create_lobby.send(lobby).unwrap();
                                 }
                                 Err(_) => {}
-                            }
-                        }
+                            };
+                        });
+                    }
 
-                        widgets::Group::new(hash!(), vec2(200.0, 25.0))
-                            .position(vec2(20.0, 60.0))
-                            .ui(ui, |ui| {
-                                ui.input_text(hash!(), "", &mut menu_state.lobby_input);
-                            });
-                    });
-            },
-            States::Chat(lobby_state) => {
-                widgets::Group::new(hash!(), vec2(800.0, 600.))
-                    .ui(&mut *root_ui(), |ui| {
-                        draw_text_ex(&format!("LobbyID: {}", lobby_state.current_lobby.raw()), 20.0, 20.0, TextParams::default());
-
-                        for (id, message) in messages.iter().enumerate() {
-                            draw_text_ex(message, 20.0, 40.0 + 20.0 * (id as f32), TextParams::default());
-                        }
-
-                        widgets::Group::new(hash!(), vec2(250.0, 25.0))
-                            .position(vec2(20.0, 570.0))
-                            .ui(ui, |ui| {
-                                ui.input_text(hash!(), "", &mut lobby_state.message);
-                            });
-
-                        //Little Client-Server logic
-                        //Host is server. Host sends message to all players
-                        //Clients send message only to host
-                        if ui.button(vec2(300.0, 570.0), "Send") {
-                            let message = format!("{}: {}", client.friends().name(), lobby_state.message);
-                            if lobby_state.is_host {
-                                for peer in lobby_state.peers.iter() {
-                                    if peer.raw() != lobby_state.own_id.raw() {
-                                        println!("SENT {} TO {}", message, peer.raw());
-                                        networking.send_p2p_packet(*peer,
-                                                                   SendType::Reliable,
-                                                                   message.as_bytes());
+                    //Try to join in lobby with id from InputField
+                    if ui.button(vec2(120.0, 40.0), "Connect") {
+                        let lobby_id: Result<u64, _> = menu_state.lobby_input.parse();
+                        match lobby_id {
+                            Ok(id) => {
+                                matchmaking.join_lobby(LobbyId::from_raw(id), move |result| {
+                                    if let Ok(lobby) = result {
+                                        local_sender_join_lobby.send(lobby).unwrap();
                                     }
-                                }
-                            } else {
-                                let result = networking.send_p2p_packet(lobby_state.host_id,
-                                                                        SendType::Reliable,
-                                                                        message.as_bytes());
-                                println!("SENT {} TO {}. RESULT: {}", message, lobby_state.host_id.raw(), result);
+                                });
                             }
-                            messages.push(message);
-                            lobby_state.message = String::new();
+                            Err(_) => {}
                         }
-                    });
+                    }
+
+                    widgets::Group::new(hash!(), vec2(200.0, 25.0))
+                        .position(vec2(20.0, 60.0))
+                        .ui(ui, |ui| {
+                            ui.input_text(hash!(), "", &mut menu_state.lobby_input);
+                        });
+                });
+            }
+            States::Chat(lobby_state) => {
+                widgets::Group::new(hash!(), vec2(800.0, 600.)).ui(&mut *root_ui(), |ui| {
+                    draw_text_ex(
+                        &format!("LobbyID: {}", lobby_state.current_lobby.raw()),
+                        20.0,
+                        20.0,
+                        TextParams::default(),
+                    );
+
+                    for (id, message) in messages.iter().enumerate() {
+                        draw_text_ex(
+                            message,
+                            20.0,
+                            40.0 + 20.0 * (id as f32),
+                            TextParams::default(),
+                        );
+                    }
+
+                    widgets::Group::new(hash!(), vec2(250.0, 25.0))
+                        .position(vec2(20.0, 570.0))
+                        .ui(ui, |ui| {
+                            ui.input_text(hash!(), "", &mut lobby_state.message);
+                        });
+
+                    //Little Client-Server logic
+                    //Host is server. Host sends message to all players
+                    //Clients send message only to host
+                    if ui.button(vec2(300.0, 570.0), "Send") {
+                        let message =
+                            format!("{}: {}", client.friends().name(), lobby_state.message);
+                        if lobby_state.is_host {
+                            for peer in lobby_state.peers.iter() {
+                                if peer.raw() != lobby_state.own_id.raw() {
+                                    println!("SENT {} TO {}", message, peer.raw());
+                                    networking.send_p2p_packet(
+                                        *peer,
+                                        SendType::Reliable,
+                                        message.as_bytes(),
+                                    );
+                                }
+                            }
+                        } else {
+                            let result = networking.send_p2p_packet(
+                                lobby_state.host_id,
+                                SendType::Reliable,
+                                message.as_bytes(),
+                            );
+                            println!(
+                                "SENT {} TO {}. RESULT: {}",
+                                message,
+                                lobby_state.host_id.raw(),
+                                result
+                            );
+                        }
+                        messages.push(message);
+                        lobby_state.message = String::new();
+                    }
+                });
 
                 while let Some(size) = networking.is_p2p_packet_available() {
                     let mut empty_array = vec![0; size];
-                    let mut buffer= empty_array.as_mut_slice();
+                    let mut buffer = empty_array.as_mut_slice();
                     if let Some((sender, _)) = networking.read_p2p_packet(&mut buffer) {
                         //Host gets message from one of the players and sends this message to other players
                         if lobby_state.is_host {
                             for peer in lobby_state.peers.iter() {
-                                if peer.raw() != lobby_state.own_id.raw() && peer.raw() != sender.raw() {
-                                    networking.send_p2p_packet(*peer,
-                                                               SendType::Reliable,
-                                                               format!("{}: {}", client.friends().name(), lobby_state.message).as_bytes());
+                                if peer.raw() != lobby_state.own_id.raw()
+                                    && peer.raw() != sender.raw()
+                                {
+                                    networking.send_p2p_packet(
+                                        *peer,
+                                        SendType::Reliable,
+                                        format!(
+                                            "{}: {}",
+                                            client.friends().name(),
+                                            lobby_state.message
+                                        )
+                                        .as_bytes(),
+                                    );
                                 }
                             }
                         }
@@ -178,8 +205,7 @@ async fn main() {
                     }
                     networking.accept_p2p_session(user);
                 }
-
-            },
+            }
         }
 
         if let Ok(lobby) = receiver_create_lobby.try_recv() {
@@ -210,9 +236,11 @@ async fn main() {
 
             //When you connected to lobby you have to send a "ping" message to host
             //After that host will add you into peer list
-            networking.send_p2p_packet(host_id,
-                                       SendType::Reliable,
-                                       format!("{} JOINED", client.friends().name()).as_bytes());
+            networking.send_p2p_packet(
+                host_id,
+                SendType::Reliable,
+                format!("{} JOINED", client.friends().name()).as_bytes(),
+            );
         }
 
         next_frame().await

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+ignore = [
+    "steamworks-sys",
+]

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,24 +16,19 @@ pub struct Apps<Manager> {
     pub(crate) _inner: Arc<Inner<Manager>>,
 }
 
-impl <Manager> Apps<Manager> {
-
+impl<Manager> Apps<Manager> {
     /// Returns whether the user currently has the app with the given
     /// ID currently installed.
     ///
     /// This does not mean the user owns the game.
     pub fn is_app_installed(&self, app_id: AppId) -> bool {
-        unsafe {
-            sys::SteamAPI_ISteamApps_BIsAppInstalled(self.apps, app_id.0)
-        }
+        unsafe { sys::SteamAPI_ISteamApps_BIsAppInstalled(self.apps, app_id.0) }
     }
 
     /// Returns whether the user owns the specific dlc and has it
     /// installed.
     pub fn is_dlc_installed(&self, app_id: AppId) -> bool {
-        unsafe {
-            sys::SteamAPI_ISteamApps_BIsDlcInstalled(self.apps, app_id.0)
-        }
+        unsafe { sys::SteamAPI_ISteamApps_BIsDlcInstalled(self.apps, app_id.0) }
     }
 
     /// Returns whether the user is subscribed to the app with the given
@@ -42,53 +37,39 @@ impl <Manager> Apps<Manager> {
     /// This should only be used to check ownership of a game related to
     /// yours (e.g. demo).
     pub fn is_subscribed_app(&self, app_id: AppId) -> bool {
-        unsafe {
-            sys::SteamAPI_ISteamApps_BIsSubscribedApp(self.apps, app_id.0)
-        }
+        unsafe { sys::SteamAPI_ISteamApps_BIsSubscribedApp(self.apps, app_id.0) }
     }
 
     /// Returns whether the user is subscribed via a free weekend
     pub fn is_subscribed_from_free_weekend(&self) -> bool {
-        unsafe {
-            sys::SteamAPI_ISteamApps_BIsSubscribedFromFreeWeekend(self.apps)
-        }
+        unsafe { sys::SteamAPI_ISteamApps_BIsSubscribedFromFreeWeekend(self.apps) }
     }
 
     /// Returns whether the user has a VAC ban on their account.
     pub fn is_vac_banned(&self) -> bool {
-        unsafe {
-            sys::SteamAPI_ISteamApps_BIsVACBanned(self.apps)
-        }
+        unsafe { sys::SteamAPI_ISteamApps_BIsVACBanned(self.apps) }
     }
 
     /// Returns whether the license for the current app ID
     /// is for cyber cafes.
     pub fn is_cybercafe(&self) -> bool {
-        unsafe {
-            sys::SteamAPI_ISteamApps_BIsCybercafe(self.apps)
-        }
+        unsafe { sys::SteamAPI_ISteamApps_BIsCybercafe(self.apps) }
     }
 
     /// Returns whether the license for the current app ID
     /// provides low violence depots.
     pub fn is_low_violence(&self) -> bool {
-        unsafe {
-            sys::SteamAPI_ISteamApps_BIsLowViolence(self.apps)
-        }
+        unsafe { sys::SteamAPI_ISteamApps_BIsLowViolence(self.apps) }
     }
 
     /// Returns whether the user is subscribed to the current app ID
     pub fn is_subscribed(&self) -> bool {
-        unsafe {
-            sys::SteamAPI_ISteamApps_BIsSubscribed(self.apps)
-        }
+        unsafe { sys::SteamAPI_ISteamApps_BIsSubscribed(self.apps) }
     }
 
     /// Returns the build id of this app.
     pub fn app_build_id(&self) -> i32 {
-        unsafe {
-            sys::SteamAPI_ISteamApps_GetAppBuildId(self.apps) as i32
-        }
+        unsafe { sys::SteamAPI_ISteamApps_GetAppBuildId(self.apps) as i32 }
     }
 
     /// Returns the installation folder of the app with the given ID.
@@ -98,7 +79,12 @@ impl <Manager> Apps<Manager> {
     pub fn app_install_dir(&self, app_id: AppId) -> String {
         unsafe {
             let mut buffer = vec![0; 2048];
-            sys::SteamAPI_ISteamApps_GetAppInstallDir(self.apps, app_id.0, buffer.as_mut_ptr(), buffer.len() as u32);
+            sys::SteamAPI_ISteamApps_GetAppInstallDir(
+                self.apps,
+                app_id.0,
+                buffer.as_mut_ptr(),
+                buffer.len() as u32,
+            );
             let path = CStr::from_ptr(buffer.as_ptr());
             path.to_string_lossy().into_owned()
         }
@@ -108,9 +94,7 @@ impl <Manager> Apps<Manager> {
     ///
     /// Differs from the current user if the app is borrowed.
     pub fn app_owner(&self) -> SteamId {
-        unsafe {
-            SteamId(sys::SteamAPI_ISteamApps_GetAppOwner(self.apps))
-        }
+        unsafe { SteamId(sys::SteamAPI_ISteamApps_GetAppOwner(self.apps)) }
     }
 
     /// Returns a list of languages that the current app supports.
@@ -119,9 +103,7 @@ impl <Manager> Apps<Manager> {
             let langs = sys::SteamAPI_ISteamApps_GetAvailableGameLanguages(self.apps);
             let langs = CStr::from_ptr(langs);
             let langs = langs.to_string_lossy();
-            langs.split(',')
-                .map(|v| v.to_owned())
-                .collect()
+            langs.split(',').map(|v| v.to_owned()).collect()
         }
     }
 
@@ -144,7 +126,11 @@ impl <Manager> Apps<Manager> {
     pub fn current_beta_name(&self) -> Option<String> {
         unsafe {
             let mut buffer = vec![0; 256];
-            if sys::SteamAPI_ISteamApps_GetCurrentBetaName(self.apps, buffer.as_mut_ptr(), buffer.len() as _) {
+            if sys::SteamAPI_ISteamApps_GetCurrentBetaName(
+                self.apps,
+                buffer.as_mut_ptr(),
+                buffer.len() as _,
+            ) {
                 let path = CStr::from_ptr(buffer.as_ptr());
                 Some(path.to_string_lossy().into_owned())
             } else {

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use crate::sys;
 
-use std::sync::{ Arc, Weak };
+use std::sync::{Arc, Weak};
 
 pub unsafe trait Callback {
     const ID: i32;
@@ -18,9 +18,9 @@ pub struct CallbackHandle<Manager = ClientManager> {
     id: i32,
     inner: Weak<Inner<Manager>>,
 }
-unsafe impl <Manager> Send for CallbackHandle<Manager> {}
+unsafe impl<Manager> Send for CallbackHandle<Manager> {}
 
-impl <Manager> Drop for CallbackHandle<Manager> {
+impl<Manager> Drop for CallbackHandle<Manager> {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.upgrade() {
             match inner.callbacks.lock() {
@@ -35,16 +35,23 @@ impl <Manager> Drop for CallbackHandle<Manager> {
     }
 }
 
-pub(crate) unsafe fn register_callback<C, F, Manager>(inner: &Arc<Inner<Manager>>, mut f: F) -> CallbackHandle<Manager>
-    where C: Callback,
-          F: FnMut(C) + Send + 'static
+pub(crate) unsafe fn register_callback<C, F, Manager>(
+    inner: &Arc<Inner<Manager>>,
+    mut f: F,
+) -> CallbackHandle<Manager>
+where
+    C: Callback,
+    F: FnMut(C) + Send + 'static,
 {
     {
         let mut callbacks = inner.callbacks.lock().unwrap();
-        callbacks.callbacks.insert(C::ID, Box::new(move |param| {
-            let param = C::from_raw(param);
-            f(param)
-        }));
+        callbacks.callbacks.insert(
+            C::ID,
+            Box::new(move |param| {
+                let param = C::from_raw(param);
+                f(param)
+            }),
+        );
     }
     CallbackHandle {
         id: C::ID,
@@ -52,11 +59,17 @@ pub(crate) unsafe fn register_callback<C, F, Manager>(inner: &Arc<Inner<Manager>
     }
 }
 
-pub(crate) unsafe fn register_call_result<C, F, Manager>(inner: &Arc<Inner<Manager>>, api_call: sys::SteamAPICall_t, _callback_id: i32, f: F)
-    where F: for <'a> FnOnce(&'a C, bool) + 'static + Send
+pub(crate) unsafe fn register_call_result<C, F, Manager>(
+    inner: &Arc<Inner<Manager>>,
+    api_call: sys::SteamAPICall_t,
+    _callback_id: i32,
+    f: F,
+) where
+    F: for<'a> FnOnce(&'a C, bool) + 'static + Send,
 {
     let mut callbacks = inner.callbacks.lock().unwrap();
-    callbacks.call_results.insert(api_call, Box::new(move |param, failed| {
-        f(&*(param as *const C), failed)
-    }));
+    callbacks.call_results.insert(
+        api_call,
+        Box::new(move |param, failed| f(&*(param as *const C), failed)),
+    );
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "serde")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 use crate::sys;
 use std::convert::TryFrom;
@@ -434,7 +434,9 @@ impl From<sys::EResult> for SteamError {
             sys::EResult::k_EResultAdministratorOK => SteamError::AdministratorOK,
             sys::EResult::k_EResultContentVersion => SteamError::ContentVersion,
             sys::EResult::k_EResultTryAnotherCM => SteamError::TryAnotherCM,
-            sys::EResult::k_EResultPasswordRequiredToKickSession => SteamError::PasswordRequiredToKickSession,
+            sys::EResult::k_EResultPasswordRequiredToKickSession => {
+                SteamError::PasswordRequiredToKickSession
+            }
             sys::EResult::k_EResultAlreadyLoggedInElsewhere => SteamError::AlreadyLoggedInElsewhere,
             sys::EResult::k_EResultSuspended => SteamError::Suspended,
             sys::EResult::k_EResultCancelled => SteamError::Cancelled,
@@ -444,7 +446,9 @@ impl From<sys::EResult> for SteamError {
             sys::EResult::k_EResultPasswordUnset => SteamError::PasswordUnset,
             sys::EResult::k_EResultExternalAccountUnlinked => SteamError::ExternalAccountUnlinked,
             sys::EResult::k_EResultPSNTicketInvalid => SteamError::PSNTicketInvalid,
-            sys::EResult::k_EResultExternalAccountAlreadyLinked => SteamError::ExternalAccountAlreadyLinked,
+            sys::EResult::k_EResultExternalAccountAlreadyLinked => {
+                SteamError::ExternalAccountAlreadyLinked
+            }
             sys::EResult::k_EResultRemoteFileConflict => SteamError::RemoteFileConflict,
             sys::EResult::k_EResultIllegalPassword => SteamError::IllegalPassword,
             sys::EResult::k_EResultSameAsPreviousValue => SteamError::SameAsPreviousValue,
@@ -454,12 +458,16 @@ impl From<sys::EResult> for SteamError {
             sys::EResult::k_EResultAccountLogonDeniedNoMail => SteamError::AccountLogonDeniedNoMail,
             sys::EResult::k_EResultHardwareNotCapableOfIPT => SteamError::HardwareNotCapableOfIPT,
             sys::EResult::k_EResultIPTInitError => SteamError::IPTInitError,
-            sys::EResult::k_EResultParentalControlRestricted => SteamError::ParentalControlRestricted,
+            sys::EResult::k_EResultParentalControlRestricted => {
+                SteamError::ParentalControlRestricted
+            }
             sys::EResult::k_EResultFacebookQueryError => SteamError::FacebookQueryError,
             sys::EResult::k_EResultExpiredLoginAuthCode => SteamError::ExpiredLoginAuthCode,
             sys::EResult::k_EResultIPLoginRestrictionFailed => SteamError::IPLoginRestrictionFailed,
             sys::EResult::k_EResultAccountLockedDown => SteamError::AccountLockedDown,
-            sys::EResult::k_EResultAccountLogonDeniedVerifiedEmailRequired => SteamError::AccountLogonDeniedVerifiedEmailRequired,
+            sys::EResult::k_EResultAccountLogonDeniedVerifiedEmailRequired => {
+                SteamError::AccountLogonDeniedVerifiedEmailRequired
+            }
             sys::EResult::k_EResultNoMatchingURL => SteamError::NoMatchingURL,
             sys::EResult::k_EResultBadResponse => SteamError::BadResponse,
             sys::EResult::k_EResultRequirePasswordReEntry => SteamError::RequirePasswordReEntry,
@@ -470,19 +478,31 @@ impl From<sys::EResult> for SteamError {
             sys::EResult::k_EResultRestrictedDevice => SteamError::RestrictedDevice,
             sys::EResult::k_EResultRegionLocked => SteamError::RegionLocked,
             sys::EResult::k_EResultRateLimitExceeded => SteamError::RateLimitExceeded,
-            sys::EResult::k_EResultAccountLoginDeniedNeedTwoFactor => SteamError::AccountLoginDeniedNeedTwoFactor,
+            sys::EResult::k_EResultAccountLoginDeniedNeedTwoFactor => {
+                SteamError::AccountLoginDeniedNeedTwoFactor
+            }
             sys::EResult::k_EResultItemDeleted => SteamError::ItemDeleted,
-            sys::EResult::k_EResultAccountLoginDeniedThrottle => SteamError::AccountLoginDeniedThrottle,
+            sys::EResult::k_EResultAccountLoginDeniedThrottle => {
+                SteamError::AccountLoginDeniedThrottle
+            }
             sys::EResult::k_EResultTwoFactorCodeMismatch => SteamError::TwoFactorCodeMismatch,
-            sys::EResult::k_EResultTwoFactorActivationCodeMismatch => SteamError::TwoFactorActivationCodeMismatch,
-            sys::EResult::k_EResultAccountAssociatedToMultiplePartners => SteamError::AccountAssociatedToMultiplePartners,
+            sys::EResult::k_EResultTwoFactorActivationCodeMismatch => {
+                SteamError::TwoFactorActivationCodeMismatch
+            }
+            sys::EResult::k_EResultAccountAssociatedToMultiplePartners => {
+                SteamError::AccountAssociatedToMultiplePartners
+            }
             sys::EResult::k_EResultNotModified => SteamError::NotModified,
             sys::EResult::k_EResultNoMobileDevice => SteamError::NoMobileDevice,
             sys::EResult::k_EResultTimeNotSynced => SteamError::TimeNotSynced,
             sys::EResult::k_EResultSmsCodeFailed => SteamError::SmsCodeFailed,
             sys::EResult::k_EResultAccountLimitExceeded => SteamError::AccountLimitExceeded,
-            sys::EResult::k_EResultAccountActivityLimitExceeded => SteamError::AccountActivityLimitExceeded,
-            sys::EResult::k_EResultPhoneActivityLimitExceeded => SteamError::PhoneActivityLimitExceeded,
+            sys::EResult::k_EResultAccountActivityLimitExceeded => {
+                SteamError::AccountActivityLimitExceeded
+            }
+            sys::EResult::k_EResultPhoneActivityLimitExceeded => {
+                SteamError::PhoneActivityLimitExceeded
+            }
             sys::EResult::k_EResultRefundToWallet => SteamError::RefundToWallet,
             sys::EResult::k_EResultEmailSendFailure => SteamError::EmailSendFailure,
             sys::EResult::k_EResultNotSettled => SteamError::NotSettled,
@@ -509,8 +529,12 @@ impl TryFrom<i64> for SteamError {
             x if x == sys::EResult::k_EResultFail as i64 => SteamError::Generic,
             x if x == sys::EResult::k_EResultNoConnection as i64 => SteamError::NoConnection,
             x if x == sys::EResult::k_EResultInvalidPassword as i64 => SteamError::InvalidPassword,
-            x if x == sys::EResult::k_EResultLoggedInElsewhere as i64 => SteamError::LoggedInElsewhere,
-            x if x == sys::EResult::k_EResultInvalidProtocolVer as i64 => SteamError::InvalidProtocolVersion,
+            x if x == sys::EResult::k_EResultLoggedInElsewhere as i64 => {
+                SteamError::LoggedInElsewhere
+            }
+            x if x == sys::EResult::k_EResultInvalidProtocolVer as i64 => {
+                SteamError::InvalidProtocolVersion
+            }
             x if x == sys::EResult::k_EResultInvalidParam as i64 => SteamError::InvalidParameter,
             x if x == sys::EResult::k_EResultFileNotFound as i64 => SteamError::FileNotFound,
             x if x == sys::EResult::k_EResultBusy as i64 => SteamError::Busy,
@@ -523,86 +547,166 @@ impl TryFrom<i64> for SteamError {
             x if x == sys::EResult::k_EResultBanned as i64 => SteamError::Banned,
             x if x == sys::EResult::k_EResultAccountNotFound as i64 => SteamError::AccountNotFound,
             x if x == sys::EResult::k_EResultInvalidSteamID as i64 => SteamError::InvalidSteamID,
-            x if x == sys::EResult::k_EResultServiceUnavailable as i64 => SteamError::ServiceUnavailable,
+            x if x == sys::EResult::k_EResultServiceUnavailable as i64 => {
+                SteamError::ServiceUnavailable
+            }
             x if x == sys::EResult::k_EResultNotLoggedOn as i64 => SteamError::NotLoggedOn,
             x if x == sys::EResult::k_EResultPending as i64 => SteamError::Pending,
-            x if x == sys::EResult::k_EResultEncryptionFailure as i64 => SteamError::EncryptionFailure,
-            x if x == sys::EResult::k_EResultInsufficientPrivilege as i64 => SteamError::InsufficientPrivilege,
+            x if x == sys::EResult::k_EResultEncryptionFailure as i64 => {
+                SteamError::EncryptionFailure
+            }
+            x if x == sys::EResult::k_EResultInsufficientPrivilege as i64 => {
+                SteamError::InsufficientPrivilege
+            }
             x if x == sys::EResult::k_EResultLimitExceeded as i64 => SteamError::LimitExceeded,
             x if x == sys::EResult::k_EResultRevoked as i64 => SteamError::Revoked,
             x if x == sys::EResult::k_EResultExpired as i64 => SteamError::Expired,
             x if x == sys::EResult::k_EResultAlreadyRedeemed as i64 => SteamError::AlreadyRedeemed,
-            x if x == sys::EResult::k_EResultDuplicateRequest as i64 => SteamError::DuplicateRequest,
+            x if x == sys::EResult::k_EResultDuplicateRequest as i64 => {
+                SteamError::DuplicateRequest
+            }
             x if x == sys::EResult::k_EResultAlreadyOwned as i64 => SteamError::AlreadyOwned,
             x if x == sys::EResult::k_EResultIPNotFound as i64 => SteamError::IPNotFound,
             x if x == sys::EResult::k_EResultPersistFailed as i64 => SteamError::PersistFailed,
             x if x == sys::EResult::k_EResultLockingFailed as i64 => SteamError::LockingFailed,
-            x if x == sys::EResult::k_EResultLogonSessionReplaced as i64 => SteamError::LogonSessionReplaced,
+            x if x == sys::EResult::k_EResultLogonSessionReplaced as i64 => {
+                SteamError::LogonSessionReplaced
+            }
             x if x == sys::EResult::k_EResultConnectFailed as i64 => SteamError::ConnectFailed,
             x if x == sys::EResult::k_EResultHandshakeFailed as i64 => SteamError::HandshakeFailed,
             x if x == sys::EResult::k_EResultIOFailure as i64 => SteamError::IOFailure,
-            x if x == sys::EResult::k_EResultRemoteDisconnect as i64 => SteamError::RemoteDisconnect,
-            x if x == sys::EResult::k_EResultShoppingCartNotFound as i64 => SteamError::ShoppingCartNotFound,
+            x if x == sys::EResult::k_EResultRemoteDisconnect as i64 => {
+                SteamError::RemoteDisconnect
+            }
+            x if x == sys::EResult::k_EResultShoppingCartNotFound as i64 => {
+                SteamError::ShoppingCartNotFound
+            }
             x if x == sys::EResult::k_EResultBlocked as i64 => SteamError::Blocked,
             x if x == sys::EResult::k_EResultIgnored as i64 => SteamError::Ignored,
             x if x == sys::EResult::k_EResultNoMatch as i64 => SteamError::NoMatch,
             x if x == sys::EResult::k_EResultAccountDisabled as i64 => SteamError::AccountDisabled,
             x if x == sys::EResult::k_EResultServiceReadOnly as i64 => SteamError::ServiceReadOnly,
-            x if x == sys::EResult::k_EResultAccountNotFeatured as i64 => SteamError::AccountNotFeatured,
+            x if x == sys::EResult::k_EResultAccountNotFeatured as i64 => {
+                SteamError::AccountNotFeatured
+            }
             x if x == sys::EResult::k_EResultAdministratorOK as i64 => SteamError::AdministratorOK,
             x if x == sys::EResult::k_EResultContentVersion as i64 => SteamError::ContentVersion,
             x if x == sys::EResult::k_EResultTryAnotherCM as i64 => SteamError::TryAnotherCM,
-            x if x == sys::EResult::k_EResultPasswordRequiredToKickSession as i64 => SteamError::PasswordRequiredToKickSession,
-            x if x == sys::EResult::k_EResultAlreadyLoggedInElsewhere as i64 => SteamError::AlreadyLoggedInElsewhere,
+            x if x == sys::EResult::k_EResultPasswordRequiredToKickSession as i64 => {
+                SteamError::PasswordRequiredToKickSession
+            }
+            x if x == sys::EResult::k_EResultAlreadyLoggedInElsewhere as i64 => {
+                SteamError::AlreadyLoggedInElsewhere
+            }
             x if x == sys::EResult::k_EResultSuspended as i64 => SteamError::Suspended,
             x if x == sys::EResult::k_EResultCancelled as i64 => SteamError::Cancelled,
             x if x == sys::EResult::k_EResultDataCorruption as i64 => SteamError::DataCorruption,
             x if x == sys::EResult::k_EResultDiskFull as i64 => SteamError::DiskFull,
-            x if x == sys::EResult::k_EResultRemoteCallFailed as i64 => SteamError::RemoteCallFailed,
+            x if x == sys::EResult::k_EResultRemoteCallFailed as i64 => {
+                SteamError::RemoteCallFailed
+            }
             x if x == sys::EResult::k_EResultPasswordUnset as i64 => SteamError::PasswordUnset,
-            x if x == sys::EResult::k_EResultExternalAccountUnlinked as i64 => SteamError::ExternalAccountUnlinked,
-            x if x == sys::EResult::k_EResultPSNTicketInvalid as i64 => SteamError::PSNTicketInvalid,
-            x if x == sys::EResult::k_EResultExternalAccountAlreadyLinked as i64 => SteamError::ExternalAccountAlreadyLinked,
-            x if x == sys::EResult::k_EResultRemoteFileConflict as i64 => SteamError::RemoteFileConflict,
+            x if x == sys::EResult::k_EResultExternalAccountUnlinked as i64 => {
+                SteamError::ExternalAccountUnlinked
+            }
+            x if x == sys::EResult::k_EResultPSNTicketInvalid as i64 => {
+                SteamError::PSNTicketInvalid
+            }
+            x if x == sys::EResult::k_EResultExternalAccountAlreadyLinked as i64 => {
+                SteamError::ExternalAccountAlreadyLinked
+            }
+            x if x == sys::EResult::k_EResultRemoteFileConflict as i64 => {
+                SteamError::RemoteFileConflict
+            }
             x if x == sys::EResult::k_EResultIllegalPassword as i64 => SteamError::IllegalPassword,
-            x if x == sys::EResult::k_EResultSameAsPreviousValue as i64 => SteamError::SameAsPreviousValue,
-            x if x == sys::EResult::k_EResultAccountLogonDenied as i64 => SteamError::AccountLogonDenied,
-            x if x == sys::EResult::k_EResultCannotUseOldPassword as i64 => SteamError::CannotUseOldPassword,
-            x if x == sys::EResult::k_EResultInvalidLoginAuthCode as i64 => SteamError::InvalidLoginAuthCode,
-            x if x == sys::EResult::k_EResultAccountLogonDeniedNoMail as i64 => SteamError::AccountLogonDeniedNoMail,
-            x if x == sys::EResult::k_EResultHardwareNotCapableOfIPT as i64 => SteamError::HardwareNotCapableOfIPT,
+            x if x == sys::EResult::k_EResultSameAsPreviousValue as i64 => {
+                SteamError::SameAsPreviousValue
+            }
+            x if x == sys::EResult::k_EResultAccountLogonDenied as i64 => {
+                SteamError::AccountLogonDenied
+            }
+            x if x == sys::EResult::k_EResultCannotUseOldPassword as i64 => {
+                SteamError::CannotUseOldPassword
+            }
+            x if x == sys::EResult::k_EResultInvalidLoginAuthCode as i64 => {
+                SteamError::InvalidLoginAuthCode
+            }
+            x if x == sys::EResult::k_EResultAccountLogonDeniedNoMail as i64 => {
+                SteamError::AccountLogonDeniedNoMail
+            }
+            x if x == sys::EResult::k_EResultHardwareNotCapableOfIPT as i64 => {
+                SteamError::HardwareNotCapableOfIPT
+            }
             x if x == sys::EResult::k_EResultIPTInitError as i64 => SteamError::IPTInitError,
-            x if x == sys::EResult::k_EResultParentalControlRestricted as i64 => SteamError::ParentalControlRestricted,
-            x if x == sys::EResult::k_EResultFacebookQueryError as i64 => SteamError::FacebookQueryError,
-            x if x == sys::EResult::k_EResultExpiredLoginAuthCode as i64 => SteamError::ExpiredLoginAuthCode,
-            x if x == sys::EResult::k_EResultIPLoginRestrictionFailed as i64 => SteamError::IPLoginRestrictionFailed,
-            x if x == sys::EResult::k_EResultAccountLockedDown as i64 => SteamError::AccountLockedDown,
-            x if x == sys::EResult::k_EResultAccountLogonDeniedVerifiedEmailRequired as i64 => SteamError::AccountLogonDeniedVerifiedEmailRequired,
+            x if x == sys::EResult::k_EResultParentalControlRestricted as i64 => {
+                SteamError::ParentalControlRestricted
+            }
+            x if x == sys::EResult::k_EResultFacebookQueryError as i64 => {
+                SteamError::FacebookQueryError
+            }
+            x if x == sys::EResult::k_EResultExpiredLoginAuthCode as i64 => {
+                SteamError::ExpiredLoginAuthCode
+            }
+            x if x == sys::EResult::k_EResultIPLoginRestrictionFailed as i64 => {
+                SteamError::IPLoginRestrictionFailed
+            }
+            x if x == sys::EResult::k_EResultAccountLockedDown as i64 => {
+                SteamError::AccountLockedDown
+            }
+            x if x == sys::EResult::k_EResultAccountLogonDeniedVerifiedEmailRequired as i64 => {
+                SteamError::AccountLogonDeniedVerifiedEmailRequired
+            }
             x if x == sys::EResult::k_EResultNoMatchingURL as i64 => SteamError::NoMatchingURL,
             x if x == sys::EResult::k_EResultBadResponse as i64 => SteamError::BadResponse,
-            x if x == sys::EResult::k_EResultRequirePasswordReEntry as i64 => SteamError::RequirePasswordReEntry,
+            x if x == sys::EResult::k_EResultRequirePasswordReEntry as i64 => {
+                SteamError::RequirePasswordReEntry
+            }
             x if x == sys::EResult::k_EResultValueOutOfRange as i64 => SteamError::ValueOutOfRange,
             x if x == sys::EResult::k_EResultUnexpectedError as i64 => SteamError::UnexpectedError,
             x if x == sys::EResult::k_EResultDisabled as i64 => SteamError::Disabled,
-            x if x == sys::EResult::k_EResultInvalidCEGSubmission as i64 => SteamError::InvalidCEGSubmission,
-            x if x == sys::EResult::k_EResultRestrictedDevice as i64 => SteamError::RestrictedDevice,
+            x if x == sys::EResult::k_EResultInvalidCEGSubmission as i64 => {
+                SteamError::InvalidCEGSubmission
+            }
+            x if x == sys::EResult::k_EResultRestrictedDevice as i64 => {
+                SteamError::RestrictedDevice
+            }
             x if x == sys::EResult::k_EResultRegionLocked as i64 => SteamError::RegionLocked,
-            x if x == sys::EResult::k_EResultRateLimitExceeded as i64 => SteamError::RateLimitExceeded,
-            x if x == sys::EResult::k_EResultAccountLoginDeniedNeedTwoFactor as i64 => SteamError::AccountLoginDeniedNeedTwoFactor,
+            x if x == sys::EResult::k_EResultRateLimitExceeded as i64 => {
+                SteamError::RateLimitExceeded
+            }
+            x if x == sys::EResult::k_EResultAccountLoginDeniedNeedTwoFactor as i64 => {
+                SteamError::AccountLoginDeniedNeedTwoFactor
+            }
             x if x == sys::EResult::k_EResultItemDeleted as i64 => SteamError::ItemDeleted,
-            x if x == sys::EResult::k_EResultAccountLoginDeniedThrottle as i64 => SteamError::AccountLoginDeniedThrottle,
-            x if x == sys::EResult::k_EResultTwoFactorCodeMismatch as i64 => SteamError::TwoFactorCodeMismatch,
-            x if x == sys::EResult::k_EResultTwoFactorActivationCodeMismatch as i64 => SteamError::TwoFactorActivationCodeMismatch,
-            x if x == sys::EResult::k_EResultAccountAssociatedToMultiplePartners as i64 => SteamError::AccountAssociatedToMultiplePartners,
+            x if x == sys::EResult::k_EResultAccountLoginDeniedThrottle as i64 => {
+                SteamError::AccountLoginDeniedThrottle
+            }
+            x if x == sys::EResult::k_EResultTwoFactorCodeMismatch as i64 => {
+                SteamError::TwoFactorCodeMismatch
+            }
+            x if x == sys::EResult::k_EResultTwoFactorActivationCodeMismatch as i64 => {
+                SteamError::TwoFactorActivationCodeMismatch
+            }
+            x if x == sys::EResult::k_EResultAccountAssociatedToMultiplePartners as i64 => {
+                SteamError::AccountAssociatedToMultiplePartners
+            }
             x if x == sys::EResult::k_EResultNotModified as i64 => SteamError::NotModified,
             x if x == sys::EResult::k_EResultNoMobileDevice as i64 => SteamError::NoMobileDevice,
             x if x == sys::EResult::k_EResultTimeNotSynced as i64 => SteamError::TimeNotSynced,
             x if x == sys::EResult::k_EResultSmsCodeFailed as i64 => SteamError::SmsCodeFailed,
-            x if x == sys::EResult::k_EResultAccountLimitExceeded as i64 => SteamError::AccountLimitExceeded,
-            x if x == sys::EResult::k_EResultAccountActivityLimitExceeded as i64 => SteamError::AccountActivityLimitExceeded,
-            x if x == sys::EResult::k_EResultPhoneActivityLimitExceeded as i64 => SteamError::PhoneActivityLimitExceeded,
+            x if x == sys::EResult::k_EResultAccountLimitExceeded as i64 => {
+                SteamError::AccountLimitExceeded
+            }
+            x if x == sys::EResult::k_EResultAccountActivityLimitExceeded as i64 => {
+                SteamError::AccountActivityLimitExceeded
+            }
+            x if x == sys::EResult::k_EResultPhoneActivityLimitExceeded as i64 => {
+                SteamError::PhoneActivityLimitExceeded
+            }
             x if x == sys::EResult::k_EResultRefundToWallet as i64 => SteamError::RefundToWallet,
-            x if x == sys::EResult::k_EResultEmailSendFailure as i64 => SteamError::EmailSendFailure,
+            x if x == sys::EResult::k_EResultEmailSendFailure as i64 => {
+                SteamError::EmailSendFailure
+            }
             x if x == sys::EResult::k_EResultNotSettled as i64 => SteamError::NotSettled,
             x if x == sys::EResult::k_EResultNeedCaptcha as i64 => SteamError::NeedCaptcha,
             x if x == sys::EResult::k_EResultGSLTDenied as i64 => SteamError::GSLTDenied,
@@ -610,11 +714,17 @@ impl TryFrom<i64> for SteamError {
             x if x == sys::EResult::k_EResultInvalidItemType as i64 => SteamError::InvalidItemType,
             x if x == sys::EResult::k_EResultIPBanned as i64 => SteamError::IPBanned,
             x if x == sys::EResult::k_EResultGSLTExpired as i64 => SteamError::GSLTExpired,
-            x if x == sys::EResult::k_EResultInsufficientFunds as i64 => SteamError::InsufficientFunds,
+            x if x == sys::EResult::k_EResultInsufficientFunds as i64 => {
+                SteamError::InsufficientFunds
+            }
             x if x == sys::EResult::k_EResultTooManyPending as i64 => SteamError::TooManyPending,
-            x if x == sys::EResult::k_EResultNoSiteLicensesFound as i64 => SteamError::NoSiteLicensesFound,
-            x if x == sys::EResult::k_EResultWGNetworkSendExceeded as i64 => SteamError::WGNetworkSendExceeded,
-            _ => return Err(InvalidErrorCode)
+            x if x == sys::EResult::k_EResultNoSiteLicensesFound as i64 => {
+                SteamError::NoSiteLicensesFound
+            }
+            x if x == sys::EResult::k_EResultWGNetworkSendExceeded as i64 => {
+                SteamError::WGNetworkSendExceeded
+            }
+            _ => return Err(InvalidErrorCode),
         };
         Ok(error)
     }

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -52,8 +52,7 @@ pub struct Friends<Manager> {
     pub(crate) inner: Arc<Inner<Manager>>,
 }
 
-impl <Manager> Friends<Manager> {
-
+impl<Manager> Friends<Manager> {
     /// Returns the (display) name of the current user
     pub fn name(&self) -> String {
         unsafe {
@@ -70,8 +69,12 @@ impl <Manager> Friends<Manager> {
                 return Vec::new();
             }
             let mut friends = Vec::with_capacity(count as usize);
-            for idx in 0 .. count {
-                let friend = SteamId(sys::SteamAPI_ISteamFriends_GetFriendByIndex(self.friends, idx, flags.bits() as _));
+            for idx in 0..count {
+                let friend = SteamId(sys::SteamAPI_ISteamFriends_GetFriendByIndex(
+                    self.friends,
+                    idx,
+                    flags.bits() as _,
+                ));
                 friends.push(Friend {
                     id: friend,
                     friends: self.friends,
@@ -104,7 +107,7 @@ impl <Manager> Friends<Manager> {
             sys::SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage(
                 self.friends,
                 url.as_ptr() as *const _,
-                sys::EActivateGameOverlayToWebPageMode::k_EActivateGameOverlayToWebPageMode_Default
+                sys::EActivateGameOverlayToWebPageMode::k_EActivateGameOverlayToWebPageMode_Default,
             );
         }
     }
@@ -115,7 +118,7 @@ impl <Manager> Friends<Manager> {
             sys::SteamAPI_ISteamFriends_ActivateGameOverlayInviteDialog(self.friends, lobby.0);
         }
     }
-    
+
     /// Set rich presence for the user. Unsets the rich presence if `value` is None or empty.
     /// See [Steam API](https://partner.steamgames.com/doc/api/ISteamFriends#SetRichPresence)
     pub fn set_rich_presence(&self, key: &str, value: Option<&str>) -> bool {
@@ -196,13 +199,13 @@ pub struct Friend<Manager> {
     _inner: Arc<Inner<Manager>>,
 }
 
-impl <Manager> Debug for Friend<Manager> {
+impl<Manager> Debug for Friend<Manager> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "Friend({:?})", self.id)
     }
 }
 
-impl <Manager> Friend<Manager> {
+impl<Manager> Friend<Manager> {
     pub fn id(&self) -> SteamId {
         self.id
     }
@@ -311,7 +314,8 @@ impl <Manager> Friend<Manager> {
             assert_eq!(width, 184);
             assert_eq!(height, 184);
             let mut dest = vec![0; 184 * 184 * 4];
-            if !sys::SteamAPI_ISteamUtils_GetImageRGBA(utils, img, dest.as_mut_ptr(), 184 * 184 * 4) {
+            if !sys::SteamAPI_ISteamUtils_GetImageRGBA(utils, img, dest.as_mut_ptr(), 184 * 184 * 4)
+            {
                 return None;
             }
             Some(dest)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
-use std::sync::{Arc, Mutex, Weak};
 use std::sync::mpsc::Sender;
+use std::sync::{Arc, Mutex, Weak};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -34,23 +34,23 @@ pub use crate::user::*;
 pub use crate::user_stats::*;
 pub use crate::utils::*;
 
-mod error;
-mod callback;
-mod server;
-mod utils;
 mod app;
+mod callback;
+mod error;
 mod friends;
 mod matchmaking;
 mod networking;
+pub mod networking_messages;
+pub mod networking_sockets;
+mod networking_sockets_callback;
+pub mod networking_types;
+pub mod networking_utils;
+mod remote_storage;
+mod server;
+mod ugc;
 mod user;
 mod user_stats;
-mod remote_storage;
-mod ugc;
-pub mod networking_messages;
-pub mod networking_types;
-pub mod networking_sockets;
-pub mod networking_utils;
-mod networking_sockets_callback;
+mod utils;
 
 pub type SResult<T> = Result<T, SteamError>;
 
@@ -95,8 +95,13 @@ struct Callbacks {
 }
 
 struct NetworkingSocketsData<Manager> {
-    sockets: HashMap<sys::HSteamListenSocket,
-        (Weak<networking_sockets::InnerSocket<Manager>>, Sender<networking_types::ListenSocketEvent<Manager>>)>,
+    sockets: HashMap<
+        sys::HSteamListenSocket,
+        (
+            Weak<networking_sockets::InnerSocket<Manager>>,
+            Sender<networking_types::ListenSocketEvent<Manager>>,
+        ),
+    >,
     /// Connections to a remote listening port
     independent_connections: HashMap<sys::HSteamNetConnection, Sender<()>>,
     connection_callback: Weak<CallbackHandle<Manager>>,

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -31,7 +31,7 @@ pub enum SendType {
     ReliableWithBuffering,
 }
 
-impl <Manager> Networking<Manager> {
+impl<Manager> Networking<Manager> {
     /// Accepts incoming packets from the given user
     ///
     /// Should only be called in response to a `P2PSessionRequest`.
@@ -58,7 +58,14 @@ impl <Manager> Networking<Manager> {
                 SendType::Reliable => sys::EP2PSend::k_EP2PSendReliable,
                 SendType::ReliableWithBuffering => sys::EP2PSend::k_EP2PSendReliableWithBuffering,
             };
-            sys::SteamAPI_ISteamNetworking_SendP2PPacket(self.net, remote.0, data.as_ptr() as *const _, data.len() as u32, send_type, 0)
+            sys::SteamAPI_ISteamNetworking_SendP2PPacket(
+                self.net,
+                remote.0,
+                data.as_ptr() as *const _,
+                data.len() as u32,
+                send_type,
+                0,
+            )
         }
     }
 
@@ -85,7 +92,14 @@ impl <Manager> Networking<Manager> {
         unsafe {
             let mut size = 0;
             let mut remote = 0;
-            if sys::SteamAPI_ISteamNetworking_ReadP2PPacket(self.net, buf.as_mut_ptr() as *mut _, buf.len() as _, &mut size, &mut remote as *mut _ as *mut _, 0) {
+            if sys::SteamAPI_ISteamNetworking_ReadP2PPacket(
+                self.net,
+                buf.as_mut_ptr() as *mut _,
+                buf.len() as _,
+                &mut size,
+                &mut remote as *mut _ as *mut _,
+                0,
+            ) {
                 Some((SteamId(remote), size as usize))
             } else {
                 None

--- a/src/networking_sockets.rs
+++ b/src/networking_sockets.rs
@@ -365,7 +365,7 @@ impl<Manager: 'static> ListenSocket<Manager> {
         messages: impl IntoIterator<Item = NetworkingMessage<Manager>>,
     ) -> Vec<SResult<MessageNumber>> {
         let messages: Vec<_> = messages.into_iter().map(|x| x.take_message()).collect();
-        let mut results = vec![0;messages.len()];
+        let mut results = vec![0; messages.len()];
         unsafe {
             sys::SteamAPI_ISteamNetworkingSockets_SendMessages(
                 self.inner.sockets,

--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -84,8 +84,7 @@ impl<Manager> NetworkingUtils<Manager> {
     pub fn detailed_relay_network_status(&self) -> RelayNetworkStatus {
         unsafe {
             let mut status = sys::SteamRelayNetworkStatus_t {
-                m_eAvail:
-                    sys::ESteamNetworkingAvailability::k_ESteamNetworkingAvailability_Unknown,
+                m_eAvail: sys::ESteamNetworkingAvailability::k_ESteamNetworkingAvailability_Unknown,
                 m_bPingMeasurementInProgress: 0,
                 m_eAvailNetworkConfig:
                     sys::ESteamNetworkingAvailability::k_ESteamNetworkingAvailability_Unknown,

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -1,4 +1,3 @@
-
 use sys::DepotId_t;
 
 use super::*;
@@ -8,8 +7,8 @@ use std::ffi::{CStr, CString};
 use std::fmt;
 use std::marker;
 use std::mem;
-use std::path::Path;
 use std::os::raw::c_char;
+use std::path::Path;
 
 pub const RESULTS_PER_PAGE: u32 = sys::kNumUGCResultsPerPage as u32;
 
@@ -58,17 +57,25 @@ impl Into<sys::EUGCMatchingUGCType> for UGCType {
         match self {
             UGCType::Items => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_Items,
             UGCType::ItemsMtx => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_Items_Mtx,
-            UGCType::ItemsReadyToUse => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_Items_ReadyToUse,
+            UGCType::ItemsReadyToUse => {
+                sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_Items_ReadyToUse
+            }
             UGCType::Collections => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_Collections,
             UGCType::Artwork => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_Artwork,
             UGCType::Videos => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_Videos,
             UGCType::Screenshots => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_Screenshots,
             UGCType::AllGuides => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_AllGuides,
             UGCType::WebGuides => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_WebGuides,
-            UGCType::IntegratedGuides => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_IntegratedGuides,
+            UGCType::IntegratedGuides => {
+                sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_IntegratedGuides
+            }
             UGCType::UsableInGame => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_UsableInGame,
-            UGCType::ControllerBindings => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_ControllerBindings,
-            UGCType::GameManagedItems => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_GameManagedItems,
+            UGCType::ControllerBindings => {
+                sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_ControllerBindings
+            }
+            UGCType::GameManagedItems => {
+                sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_GameManagedItems
+            }
             UGCType::All => sys::EUGCMatchingUGCType::k_EUGCMatchingUGCType_All,
         }
     }
@@ -98,7 +105,9 @@ impl Into<sys::EWorkshopFileType> for FileType {
     fn into(self) -> sys::EWorkshopFileType {
         match self {
             FileType::Community => sys::EWorkshopFileType::k_EWorkshopFileTypeCommunity,
-            FileType::Microtransaction => sys::EWorkshopFileType::k_EWorkshopFileTypeMicrotransaction,
+            FileType::Microtransaction => {
+                sys::EWorkshopFileType::k_EWorkshopFileTypeMicrotransaction
+            }
             FileType::Collection => sys::EWorkshopFileType::k_EWorkshopFileTypeCollection,
             FileType::Art => sys::EWorkshopFileType::k_EWorkshopFileTypeArt,
             FileType::Video => sys::EWorkshopFileType::k_EWorkshopFileTypeVideo,
@@ -109,8 +118,12 @@ impl Into<sys::EWorkshopFileType> for FileType {
             FileType::WebGuide => sys::EWorkshopFileType::k_EWorkshopFileTypeWebGuide,
             FileType::IntegratedGuide => sys::EWorkshopFileType::k_EWorkshopFileTypeIntegratedGuide,
             FileType::Merch => sys::EWorkshopFileType::k_EWorkshopFileTypeMerch,
-            FileType::ControllerBinding => sys::EWorkshopFileType::k_EWorkshopFileTypeControllerBinding,
-            FileType::SteamworksAccessInvite => sys::EWorkshopFileType::k_EWorkshopFileTypeSteamworksAccessInvite,
+            FileType::ControllerBinding => {
+                sys::EWorkshopFileType::k_EWorkshopFileTypeControllerBinding
+            }
+            FileType::SteamworksAccessInvite => {
+                sys::EWorkshopFileType::k_EWorkshopFileTypeSteamworksAccessInvite
+            }
             FileType::SteamVideo => sys::EWorkshopFileType::k_EWorkshopFileTypeSteamVideo,
             FileType::GameManagedItem => sys::EWorkshopFileType::k_EWorkshopFileTypeGameManagedItem,
         }
@@ -120,7 +133,9 @@ impl From<sys::EWorkshopFileType> for FileType {
     fn from(file_type: sys::EWorkshopFileType) -> FileType {
         match file_type {
             sys::EWorkshopFileType::k_EWorkshopFileTypeCommunity => FileType::Community,
-            sys::EWorkshopFileType::k_EWorkshopFileTypeMicrotransaction => FileType::Microtransaction,
+            sys::EWorkshopFileType::k_EWorkshopFileTypeMicrotransaction => {
+                FileType::Microtransaction
+            }
             sys::EWorkshopFileType::k_EWorkshopFileTypeCollection => FileType::Collection,
             sys::EWorkshopFileType::k_EWorkshopFileTypeArt => FileType::Art,
             sys::EWorkshopFileType::k_EWorkshopFileTypeVideo => FileType::Video,
@@ -131,11 +146,15 @@ impl From<sys::EWorkshopFileType> for FileType {
             sys::EWorkshopFileType::k_EWorkshopFileTypeWebGuide => FileType::WebGuide,
             sys::EWorkshopFileType::k_EWorkshopFileTypeIntegratedGuide => FileType::IntegratedGuide,
             sys::EWorkshopFileType::k_EWorkshopFileTypeMerch => FileType::Merch,
-            sys::EWorkshopFileType::k_EWorkshopFileTypeControllerBinding => FileType::ControllerBinding,
-            sys::EWorkshopFileType::k_EWorkshopFileTypeSteamworksAccessInvite => FileType::SteamworksAccessInvite,
+            sys::EWorkshopFileType::k_EWorkshopFileTypeControllerBinding => {
+                FileType::ControllerBinding
+            }
+            sys::EWorkshopFileType::k_EWorkshopFileTypeSteamworksAccessInvite => {
+                FileType::SteamworksAccessInvite
+            }
             sys::EWorkshopFileType::k_EWorkshopFileTypeSteamVideo => FileType::SteamVideo,
             sys::EWorkshopFileType::k_EWorkshopFileTypeGameManagedItem => FileType::GameManagedItem,
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 }
@@ -182,20 +201,32 @@ pub enum UserListOrder {
 impl Into<sys::EUserUGCListSortOrder> for UserListOrder {
     fn into(self) -> sys::EUserUGCListSortOrder {
         match self {
-            UserListOrder::CreationOrderAsc => sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_CreationOrderAsc,
-            UserListOrder::CreationOrderDesc => sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_CreationOrderDesc,
+            UserListOrder::CreationOrderAsc => {
+                sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_CreationOrderAsc
+            }
+            UserListOrder::CreationOrderDesc => {
+                sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_CreationOrderDesc
+            }
             UserListOrder::TitleAsc => sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_TitleAsc,
-            UserListOrder::LastUpdatedDesc => sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_LastUpdatedDesc,
-            UserListOrder::SubscriptionDateDesc => sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_SubscriptionDateDesc,
-            UserListOrder::VoteScoreDesc => sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_VoteScoreDesc,
-            UserListOrder::ForModeration => sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_ForModeration,
+            UserListOrder::LastUpdatedDesc => {
+                sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_LastUpdatedDesc
+            }
+            UserListOrder::SubscriptionDateDesc => {
+                sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_SubscriptionDateDesc
+            }
+            UserListOrder::VoteScoreDesc => {
+                sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_VoteScoreDesc
+            }
+            UserListOrder::ForModeration => {
+                sys::EUserUGCListSortOrder::k_EUserUGCListSortOrder_ForModeration
+            }
         }
     }
 }
 
 /// Available user-specific lists.
 /// Certain ones are only available to the currently logged in user.
-#[derive(Debug,Clone,Copy,PartialEq,Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UserList {
     /// Files user has published
     Published,
@@ -206,7 +237,7 @@ pub enum UserList {
     /// Files user has voted down (current user only)
     VotedDown,
     /// Deprecated
-    #[deprecated(note="Deprecated in Steam API")]
+    #[deprecated(note = "Deprecated in Steam API")]
     WillVoteLater,
     /// Files user has favorited
     Favorited,
@@ -235,7 +266,7 @@ impl Into<sys::EUserUGCList> for UserList {
 }
 
 /// Available published item statistic types.
-#[derive(Debug,Clone,Copy,PartialEq,Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UGCStatisticType {
     /// The number of subscriptions.
     Subscriptions,
@@ -267,19 +298,37 @@ pub enum UGCStatisticType {
 impl Into<sys::EItemStatistic> for UGCStatisticType {
     fn into(self) -> sys::EItemStatistic {
         match self {
-            UGCStatisticType::Subscriptions => sys::EItemStatistic::k_EItemStatistic_NumSubscriptions,
+            UGCStatisticType::Subscriptions => {
+                sys::EItemStatistic::k_EItemStatistic_NumSubscriptions
+            }
             UGCStatisticType::Favorites => sys::EItemStatistic::k_EItemStatistic_NumFavorites,
             UGCStatisticType::Followers => sys::EItemStatistic::k_EItemStatistic_NumFollowers,
-            UGCStatisticType::UniqueSubscriptions => sys::EItemStatistic::k_EItemStatistic_NumUniqueSubscriptions,
-            UGCStatisticType::UniqueFavorites => sys::EItemStatistic::k_EItemStatistic_NumUniqueFavorites,
-            UGCStatisticType::UniqueFollowers => sys::EItemStatistic::k_EItemStatistic_NumUniqueFollowers,
-            UGCStatisticType::UniqueWebsiteViews => sys::EItemStatistic::k_EItemStatistic_NumUniqueWebsiteViews,
+            UGCStatisticType::UniqueSubscriptions => {
+                sys::EItemStatistic::k_EItemStatistic_NumUniqueSubscriptions
+            }
+            UGCStatisticType::UniqueFavorites => {
+                sys::EItemStatistic::k_EItemStatistic_NumUniqueFavorites
+            }
+            UGCStatisticType::UniqueFollowers => {
+                sys::EItemStatistic::k_EItemStatistic_NumUniqueFollowers
+            }
+            UGCStatisticType::UniqueWebsiteViews => {
+                sys::EItemStatistic::k_EItemStatistic_NumUniqueWebsiteViews
+            }
             UGCStatisticType::Reports => sys::EItemStatistic::k_EItemStatistic_ReportScore,
-            UGCStatisticType::SecondsPlayed => sys::EItemStatistic::k_EItemStatistic_NumSecondsPlayed,
-            UGCStatisticType::PlaytimeSessions => sys::EItemStatistic::k_EItemStatistic_NumPlaytimeSessions,
+            UGCStatisticType::SecondsPlayed => {
+                sys::EItemStatistic::k_EItemStatistic_NumSecondsPlayed
+            }
+            UGCStatisticType::PlaytimeSessions => {
+                sys::EItemStatistic::k_EItemStatistic_NumPlaytimeSessions
+            }
             UGCStatisticType::Comments => sys::EItemStatistic::k_EItemStatistic_NumComments,
-            UGCStatisticType::SecondsPlayedDuringTimePeriod => sys::EItemStatistic::k_EItemStatistic_NumSecondsPlayedDuringTimePeriod,
-            UGCStatisticType::PlaytimeSessionsDuringTimePeriod => sys::EItemStatistic::k_EItemStatistic_NumPlaytimeSessionsDuringTimePeriod,
+            UGCStatisticType::SecondsPlayedDuringTimePeriod => {
+                sys::EItemStatistic::k_EItemStatistic_NumSecondsPlayedDuringTimePeriod
+            }
+            UGCStatisticType::PlaytimeSessionsDuringTimePeriod => {
+                sys::EItemStatistic::k_EItemStatistic_NumPlaytimeSessionsDuringTimePeriod
+            }
         }
     }
 }
@@ -316,8 +365,8 @@ unsafe impl Callback for DownloadItemResult {
 
             error: match val.m_eResult {
                 sys::EResult::k_EResultOK => None,
-                error => Some(error.into())
-            }
+                error => Some(error.into()),
+            },
         }
     }
 }
@@ -330,7 +379,7 @@ pub struct InstallInfo {
     pub timestamp: u32,
 }
 
-impl <Manager> UGC<Manager> {
+impl<Manager> UGC<Manager> {
     /// Suspends or resumes all workshop downloads
     pub fn suspend_downloads(&self, suspend: bool) {
         unsafe {
@@ -340,12 +389,15 @@ impl <Manager> UGC<Manager> {
 
     /// Creates a workshop item
     pub fn create_item<F>(&self, app_id: AppId, file_type: FileType, cb: F)
-        where F: FnOnce(Result<(PublishedFileId, bool), SteamError>) + 'static + Send
+    where
+        F: FnOnce(Result<(PublishedFileId, bool), SteamError>) + 'static + Send,
     {
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_CreateItem(self.ugc, app_id.0, file_type.into());
             register_call_result::<sys::CreateItemResult_t, _, _>(
-                &self.inner, api_call, CALLBACK_BASE_ID + 3,
+                &self.inner,
+                api_call,
+                CALLBACK_BASE_ID + 3,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -357,13 +409,18 @@ impl <Manager> UGC<Manager> {
                             v.m_bUserNeedsToAcceptWorkshopLegalAgreement,
                         ))
                     })
-            });
+                },
+            );
         }
     }
 
     /// Starts an item update process
     #[must_use]
-    pub fn start_item_update(&self, app_id: AppId, file_id: PublishedFileId) -> UpdateHandle<Manager> {
+    pub fn start_item_update(
+        &self,
+        app_id: AppId,
+        file_id: PublishedFileId,
+    ) -> UpdateHandle<Manager> {
         unsafe {
             let handle = sys::SteamAPI_ISteamUGC_StartItemUpdate(self.ugc, app_id.0, file_id.0);
             UpdateHandle {
@@ -377,12 +434,15 @@ impl <Manager> UGC<Manager> {
 
     /// Subscribes to a workshop item
     pub fn subscribe_item<F>(&self, published_file_id: PublishedFileId, cb: F)
-        where F: FnOnce(Result<(), SteamError>) + 'static + Send
+    where
+        F: FnOnce(Result<(), SteamError>) + 'static + Send,
     {
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_SubscribeItem(self.ugc, published_file_id.0);
             register_call_result::<sys::RemoteStorageSubscribePublishedFileResult_t, _, _>(
-                &self.inner, api_call, CALLBACK_REMOTE_STORAGE_BASE_ID + 13,
+                &self.inner,
+                api_call,
+                CALLBACK_REMOTE_STORAGE_BASE_ID + 13,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -391,17 +451,21 @@ impl <Manager> UGC<Manager> {
                     } else {
                         Ok(())
                     })
-            });
+                },
+            );
         }
     }
 
     pub fn unsubscribe_item<F>(&self, published_file_id: PublishedFileId, cb: F)
-        where F: FnOnce(Result<(), SteamError>) + 'static + Send
+    where
+        F: FnOnce(Result<(), SteamError>) + 'static + Send,
     {
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_UnsubscribeItem(self.ugc, published_file_id.0);
             register_call_result::<sys::RemoteStorageUnsubscribePublishedFileResult_t, _, _>(
-                &self.inner, api_call, CALLBACK_REMOTE_STORAGE_BASE_ID + 15,
+                &self.inner,
+                api_call,
+                CALLBACK_REMOTE_STORAGE_BASE_ID + 15,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -410,7 +474,8 @@ impl <Manager> UGC<Manager> {
                     } else {
                         Ok(())
                     })
-            });
+                },
+            );
         }
     }
 
@@ -419,11 +484,10 @@ impl <Manager> UGC<Manager> {
         unsafe {
             let count = sys::SteamAPI_ISteamUGC_GetNumSubscribedItems(self.ugc);
             let mut data: Vec<sys::PublishedFileId_t> = vec![0; count as usize];
-            let gotten_count = sys::SteamAPI_ISteamUGC_GetSubscribedItems(self.ugc, data.as_mut_ptr(), count);
+            let gotten_count =
+                sys::SteamAPI_ISteamUGC_GetSubscribedItems(self.ugc, data.as_mut_ptr(), count);
             debug_assert!(count == gotten_count);
-            data.into_iter()
-                .map(|v| PublishedFileId(v))
-                .collect()
+            data.into_iter().map(|v| PublishedFileId(v)).collect()
         }
     }
 
@@ -438,7 +502,12 @@ impl <Manager> UGC<Manager> {
         unsafe {
             let mut current = 0u64;
             let mut total = 0u64;
-            if sys::SteamAPI_ISteamUGC_GetItemDownloadInfo(self.ugc, item.0, &mut current, &mut total) {
+            if sys::SteamAPI_ISteamUGC_GetItemDownloadInfo(
+                self.ugc,
+                item.0,
+                &mut current,
+                &mut total,
+            ) {
                 Some((current, total))
             } else {
                 None
@@ -451,7 +520,14 @@ impl <Manager> UGC<Manager> {
             let mut size_on_disk = 0u64;
             let mut folder = [0 as c_char; 4096];
             let mut timestamp = 0u32;
-            if sys::SteamAPI_ISteamUGC_GetItemInstallInfo(self.ugc, item.0, &mut size_on_disk, folder.as_mut_ptr(), folder.len() as _, &mut timestamp) {
+            if sys::SteamAPI_ISteamUGC_GetItemInstallInfo(
+                self.ugc,
+                item.0,
+                &mut size_on_disk,
+                folder.as_mut_ptr(),
+                folder.len() as _,
+                &mut timestamp,
+            ) {
                 Some(InstallInfo {
                     folder: CStr::from_ptr(folder.as_ptr() as *const _)
                         .to_string_lossy()
@@ -466,19 +542,18 @@ impl <Manager> UGC<Manager> {
     }
 
     pub fn download_item(&self, item: PublishedFileId, high_priority: bool) -> bool {
-        unsafe {
-            sys::SteamAPI_ISteamUGC_DownloadItem(self.ugc, item.0, high_priority)
-        }
+        unsafe { sys::SteamAPI_ISteamUGC_DownloadItem(self.ugc, item.0, high_priority) }
     }
 
     /// Queries a list of workshop itmes, related to a user in some way (Ex. user's subscriptions, favorites, upvoted, ...)
-    pub fn query_user(&self,
+    pub fn query_user(
+        &self,
         account: AccountId,
         list_type: UserList,
         item_type: UGCType,
         sort_order: UserListOrder,
         appids: AppIDs,
-        page: u32
+        page: u32,
     ) -> Result<UserListQuery<Manager>, CreateQueryError> {
         let res = unsafe {
             sys::SteamAPI_ISteamUGC_CreateQueryUserUGCRequest(
@@ -504,14 +579,17 @@ impl <Manager> UGC<Manager> {
         })
     }
 
-    pub fn query_items(&self, mut items: Vec<PublishedFileId>) -> Result<ItemListDetailsQuery<Manager>, CreateQueryError> {
+    pub fn query_items(
+        &self,
+        mut items: Vec<PublishedFileId>,
+    ) -> Result<ItemListDetailsQuery<Manager>, CreateQueryError> {
         debug_assert!(items.len() > 0);
 
         let res = unsafe {
             sys::SteamAPI_ISteamUGC_CreateQueryUGCDetailsRequest(
                 self.ugc,
                 items.as_mut_ptr() as _,
-                items.len() as _
+                items.len() as _,
             )
         };
 
@@ -526,14 +604,17 @@ impl <Manager> UGC<Manager> {
         })
     }
 
-    pub fn query_item(&self, item: PublishedFileId) -> Result<ItemDetailsQuery<Manager>, CreateQueryError> {
+    pub fn query_item(
+        &self,
+        item: PublishedFileId,
+    ) -> Result<ItemDetailsQuery<Manager>, CreateQueryError> {
         let mut items = vec![item];
 
         let res = unsafe {
             sys::SteamAPI_ISteamUGC_CreateQueryUGCDetailsRequest(
                 self.ugc,
                 items.as_mut_ptr() as _,
-                1 as _
+                1 as _,
             )
         };
 
@@ -550,37 +631,47 @@ impl <Manager> UGC<Manager> {
 
     /// **DELETES** the item from the Steam Workshop.
     pub fn delete_item<F>(&self, published_file_id: PublishedFileId, cb: F)
-        where F: FnOnce(Result<(), SteamError>) + 'static + Send
+    where
+        F: FnOnce(Result<(), SteamError>) + 'static + Send,
     {
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_DeleteItem(self.ugc, published_file_id.0);
             register_call_result::<sys::DownloadItemResult_t, _, _>(
-                &self.inner, api_call, CALLBACK_REMOTE_STORAGE_BASE_ID + 17,
+                &self.inner,
+                api_call,
+                CALLBACK_REMOTE_STORAGE_BASE_ID + 17,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
-                    } else if v.m_eResult != sys::EResult::k_EResultNone && v.m_eResult != sys::EResult::k_EResultOK {
+                    } else if v.m_eResult != sys::EResult::k_EResultNone
+                        && v.m_eResult != sys::EResult::k_EResultOK
+                    {
                         Err(v.m_eResult.into())
                     } else {
                         Ok(())
                     })
-            });
+                },
+            );
         }
     }
 }
 
 impl UGC<ServerManager> {
     /// Initialize this UGC interface for a Steam game server.
-    /// 
+    ///
     /// You should pass in the Workshop depot, you can find this on SteamDB. It's usually just the app ID.
-    /// 
+    ///
     /// The folder is a path to the directory where you wish for this game server to store UGC content.
-    /// 
+    ///
     /// `true` upon success; otherwise, `false` if the calling user is not a game server or if the workshop is currently updating its content.
     pub fn init_for_game_server(&self, workshop_depot: DepotId_t, folder: &str) -> bool {
         unsafe {
             let folder = CString::new(folder).unwrap();
-            sys::SteamAPI_ISteamUGC_BInitWorkshopForGameServer(self.ugc, workshop_depot, folder.as_ptr())
+            sys::SteamAPI_ISteamUGC_BInitWorkshopForGameServer(
+                self.ugc,
+                workshop_depot,
+                folder.as_ptr(),
+            )
         }
     }
 }
@@ -593,12 +684,16 @@ pub struct UpdateHandle<Manager> {
     handle: sys::UGCUpdateHandle_t,
 }
 
-impl <Manager> UpdateHandle<Manager> {
+impl<Manager> UpdateHandle<Manager> {
     #[must_use]
     pub fn title(self, title: &str) -> Self {
         unsafe {
             let title = CString::new(title).unwrap();
-            assert!(sys::SteamAPI_ISteamUGC_SetItemTitle(self.ugc, self.handle, title.as_ptr()));
+            assert!(sys::SteamAPI_ISteamUGC_SetItemTitle(
+                self.ugc,
+                self.handle,
+                title.as_ptr()
+            ));
         }
         self
     }
@@ -607,7 +702,11 @@ impl <Manager> UpdateHandle<Manager> {
     pub fn description(self, description: &str) -> Self {
         unsafe {
             let description = CString::new(description).unwrap();
-            assert!(sys::SteamAPI_ISteamUGC_SetItemDescription(self.ugc, self.handle, description.as_ptr()));
+            assert!(sys::SteamAPI_ISteamUGC_SetItemDescription(
+                self.ugc,
+                self.handle,
+                description.as_ptr()
+            ));
         }
         self
     }
@@ -617,7 +716,11 @@ impl <Manager> UpdateHandle<Manager> {
         unsafe {
             let path = path.canonicalize().unwrap();
             let preview_path = CString::new(&*path.to_string_lossy()).unwrap();
-            assert!(sys::SteamAPI_ISteamUGC_SetItemPreview(self.ugc, self.handle, preview_path.as_ptr()));
+            assert!(sys::SteamAPI_ISteamUGC_SetItemPreview(
+                self.ugc,
+                self.handle,
+                preview_path.as_ptr()
+            ));
         }
         self
     }
@@ -627,7 +730,11 @@ impl <Manager> UpdateHandle<Manager> {
         unsafe {
             let path = path.canonicalize().unwrap();
             let content_path = CString::new(&*path.to_string_lossy()).unwrap();
-            assert!(sys::SteamAPI_ISteamUGC_SetItemContent(self.ugc, self.handle, content_path.as_ptr()));
+            assert!(sys::SteamAPI_ISteamUGC_SetItemContent(
+                self.ugc,
+                self.handle,
+                content_path.as_ptr()
+            ));
         }
         self
     }
@@ -635,13 +742,18 @@ impl <Manager> UpdateHandle<Manager> {
     pub fn tags<S: AsRef<str>>(self, tags: Vec<S>) -> Self {
         unsafe {
             let mut tags = SteamParamStringArray::new(&tags);
-            assert!(sys::SteamAPI_ISteamUGC_SetItemTags(self.ugc, self.handle, &tags.as_raw()));
+            assert!(sys::SteamAPI_ISteamUGC_SetItemTags(
+                self.ugc,
+                self.handle,
+                &tags.as_raw()
+            ));
         }
         self
     }
 
     pub fn submit<F>(self, change_note: Option<&str>, cb: F) -> UpdateWatchHandle<Manager>
-        where F: FnOnce(Result<(PublishedFileId, bool), SteamError>) + 'static + Send
+    where
+        F: FnOnce(Result<(PublishedFileId, bool), SteamError>) + 'static + Send,
     {
         use std::ptr;
         unsafe {
@@ -649,7 +761,9 @@ impl <Manager> UpdateHandle<Manager> {
             let note = change_note.as_ref().map_or(ptr::null(), |v| v.as_ptr());
             let api_call = sys::SteamAPI_ISteamUGC_SubmitItemUpdate(self.ugc, self.handle, note);
             register_call_result::<sys::SubmitItemUpdateResult_t, _, _>(
-                &self.inner, api_call, CALLBACK_BASE_ID + 4,
+                &self.inner,
+                api_call,
+                CALLBACK_BASE_ID + 4,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -661,7 +775,8 @@ impl <Manager> UpdateHandle<Manager> {
                             v.m_bUserNeedsToAcceptWorkshopLegalAgreement,
                         ))
                     })
-            });
+                },
+            );
         }
         UpdateWatchHandle {
             ugc: self.ugc,
@@ -679,22 +794,37 @@ pub struct UpdateWatchHandle<Manager> {
     handle: sys::UGCUpdateHandle_t,
 }
 
-unsafe impl <Manager> Send for UpdateWatchHandle<Manager> {}
-unsafe impl <Manager> Sync for UpdateWatchHandle<Manager> {}
+unsafe impl<Manager> Send for UpdateWatchHandle<Manager> {}
+unsafe impl<Manager> Sync for UpdateWatchHandle<Manager> {}
 
-impl <Manager> UpdateWatchHandle<Manager> {
+impl<Manager> UpdateWatchHandle<Manager> {
     pub fn progress(&self) -> (UpdateStatus, u64, u64) {
         unsafe {
             let mut progress = 0;
             let mut total = 0;
-            let status = sys::SteamAPI_ISteamUGC_GetItemUpdateProgress(self.ugc, self.handle, &mut progress, &mut total);
+            let status = sys::SteamAPI_ISteamUGC_GetItemUpdateProgress(
+                self.ugc,
+                self.handle,
+                &mut progress,
+                &mut total,
+            );
             let status = match status {
                 sys::EItemUpdateStatus::k_EItemUpdateStatusInvalid => UpdateStatus::Invalid,
-                sys::EItemUpdateStatus::k_EItemUpdateStatusPreparingConfig => UpdateStatus::PreparingConfig,
-                sys::EItemUpdateStatus::k_EItemUpdateStatusPreparingContent => UpdateStatus::PreparingContent,
-                sys::EItemUpdateStatus::k_EItemUpdateStatusUploadingContent => UpdateStatus::UploadingContent,
-                sys::EItemUpdateStatus::k_EItemUpdateStatusUploadingPreviewFile => UpdateStatus::UploadingPreviewFile,
-                sys::EItemUpdateStatus::k_EItemUpdateStatusCommittingChanges => UpdateStatus::CommittingChanges,
+                sys::EItemUpdateStatus::k_EItemUpdateStatusPreparingConfig => {
+                    UpdateStatus::PreparingConfig
+                }
+                sys::EItemUpdateStatus::k_EItemUpdateStatusPreparingContent => {
+                    UpdateStatus::PreparingContent
+                }
+                sys::EItemUpdateStatus::k_EItemUpdateStatusUploadingContent => {
+                    UpdateStatus::UploadingContent
+                }
+                sys::EItemUpdateStatus::k_EItemUpdateStatusUploadingPreviewFile => {
+                    UpdateStatus::UploadingPreviewFile
+                }
+                sys::EItemUpdateStatus::k_EItemUpdateStatusCommittingChanges => {
+                    UpdateStatus::CommittingChanges
+                }
                 _ => unreachable!(),
             };
             (status, progress, total)
@@ -721,7 +851,7 @@ pub struct UserListQuery<Manager> {
     // to prevent the handle from being dropped when this query is dropped.
     handle: Option<sys::UGCQueryHandle_t>,
 }
-impl <Manager> Drop for UserListQuery<Manager> {
+impl<Manager> Drop for UserListQuery<Manager> {
     fn drop(&mut self) {
         if let Some(handle) = self.handle.as_mut() {
             unsafe {
@@ -730,12 +860,13 @@ impl <Manager> Drop for UserListQuery<Manager> {
         }
     }
 }
-impl <Manager> UserListQuery<Manager> {
+impl<Manager> UserListQuery<Manager> {
     /// Excludes items with a specific tag.
     ///
     /// Panics if `tag` could not be converted to a `CString`.
     pub fn exclude_tag(self, tag: &str) -> Self {
-        let cstr = CString::new(tag).expect("String passed to exclude_tag could not be converted to a c string");
+        let cstr = CString::new(tag)
+            .expect("String passed to exclude_tag could not be converted to a c string");
         let ok = unsafe {
             sys::SteamAPI_ISteamUGC_AddExcludedTag(self.ugc, self.handle.unwrap(), cstr.as_ptr())
         };
@@ -747,7 +878,8 @@ impl <Manager> UserListQuery<Manager> {
     ///
     /// Panics if `tag` could not be converted to a `CString`.
     pub fn require_tag(self, tag: &str) -> Self {
-        let cstr = CString::new(tag).expect("String passed to require_tag could not be converted to a c string");
+        let cstr = CString::new(tag)
+            .expect("String passed to require_tag could not be converted to a c string");
         let ok = unsafe {
             sys::SteamAPI_ISteamUGC_AddRequiredTag(self.ugc, self.handle.unwrap(), cstr.as_ptr())
         };
@@ -757,9 +889,8 @@ impl <Manager> UserListQuery<Manager> {
 
     /// Sets how to match tags added by `require_tag`. If `true`, then any tag may match. If `false`, all required tags must match.
     pub fn any_required(self, any: bool) -> Self {
-        let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_SetMatchAnyTag(self.ugc, self.handle.unwrap(), any)
-        };
+        let ok =
+            unsafe { sys::SteamAPI_ISteamUGC_SetMatchAnyTag(self.ugc, self.handle.unwrap(), any) };
         debug_assert!(ok);
         self
     }
@@ -768,7 +899,8 @@ impl <Manager> UserListQuery<Manager> {
     ///
     /// Defaults to "english"
     pub fn language(self, language: &str) -> Self {
-        let cstr = CString::new(language).expect("String passed to language could not be converted to a c string");
+        let cstr = CString::new(language)
+            .expect("String passed to language could not be converted to a c string");
         let ok = unsafe {
             sys::SteamAPI_ISteamUGC_SetLanguage(self.ugc, self.handle.unwrap(), cstr.as_ptr())
         };
@@ -781,7 +913,11 @@ impl <Manager> UserListQuery<Manager> {
     /// Age is in seconds.
     pub fn allow_cached_response(self, max_age_s: u32) -> Self {
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_SetAllowCachedResponse(self.ugc, self.handle.unwrap(), max_age_s)
+            sys::SteamAPI_ISteamUGC_SetAllowCachedResponse(
+                self.ugc,
+                self.handle.unwrap(),
+                max_age_s,
+            )
         };
         debug_assert!(ok);
         self
@@ -790,7 +926,11 @@ impl <Manager> UserListQuery<Manager> {
     /// Include the full description in results
     pub fn include_long_desc(self, include: bool) -> Self {
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_SetReturnLongDescription(self.ugc, self.handle.unwrap(), include)
+            sys::SteamAPI_ISteamUGC_SetReturnLongDescription(
+                self.ugc,
+                self.handle.unwrap(),
+                include,
+            )
         };
         debug_assert!(ok);
         self
@@ -817,7 +957,11 @@ impl <Manager> UserListQuery<Manager> {
     /// Include additional previews in results
     pub fn include_additional_previews(self, include: bool) -> Self {
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_SetReturnAdditionalPreviews(self.ugc, self.handle.unwrap(), include)
+            sys::SteamAPI_ISteamUGC_SetReturnAdditionalPreviews(
+                self.ugc,
+                self.handle.unwrap(),
+                include,
+            )
         };
         debug_assert!(ok);
         self
@@ -834,7 +978,8 @@ impl <Manager> UserListQuery<Manager> {
 
     /// Runs the query
     pub fn fetch<F>(mut self, cb: F)
-        where F: for<'a> FnOnce(Result<QueryResults<'a>,SteamError>) + 'static + Send
+    where
+        F: for<'a> FnOnce(Result<QueryResults<'a>, SteamError>) + 'static + Send,
     {
         let ugc = self.ugc;
         let inner = Arc::clone(&self.inner);
@@ -844,7 +989,9 @@ impl <Manager> UserListQuery<Manager> {
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_SendQueryUGCRequest(ugc, handle);
             register_call_result::<sys::SteamUGCQueryCompleted_t, _, _>(
-                &inner, api_call, CALLBACK_BASE_ID + 1,
+                &inner,
+                api_call,
+                CALLBACK_BASE_ID + 1,
                 move |v, io_error| {
                     let ugc = sys::SteamAPI_SteamUGC_v016();
                     if io_error {
@@ -866,16 +1013,19 @@ impl <Manager> UserListQuery<Manager> {
                         _phantom: Default::default(),
                     };
                     cb(Ok(result));
-            });
+                },
+            );
         }
     }
 
     /// Runs the query, only fetching the total number of results.
     pub fn fetch_total<F>(self, cb: F)
-        where F: Fn(Result<u32, SteamError>) + 'static + Send
+    where
+        F: Fn(Result<u32, SteamError>) + 'static + Send,
     {
         unsafe {
-            let ok = sys::SteamAPI_ISteamUGC_SetReturnTotalOnly(self.ugc, self.handle.unwrap(), true);
+            let ok =
+                sys::SteamAPI_ISteamUGC_SetReturnTotalOnly(self.ugc, self.handle.unwrap(), true);
             debug_assert!(ok);
         }
 
@@ -884,15 +1034,21 @@ impl <Manager> UserListQuery<Manager> {
 
     /// Runs the query, only fetching the IDs.
     pub fn fetch_ids<F>(self, cb: F)
-        where F: Fn(Result<Vec<PublishedFileId>, SteamError>) + 'static + Send
+    where
+        F: Fn(Result<Vec<PublishedFileId>, SteamError>) + 'static + Send,
     {
         unsafe {
             let ok = sys::SteamAPI_ISteamUGC_SetReturnOnlyIDs(self.ugc, self.handle.unwrap(), true);
             debug_assert!(ok);
         }
 
-        self.fetch(move |res|
-            cb(res.map(|qr| qr.iter().filter_map(|v| v.map(|v| PublishedFileId(v.published_file_id.0))).collect::<Vec<_>>())))
+        self.fetch(move |res| {
+            cb(res.map(|qr| {
+                qr.iter()
+                    .filter_map(|v| v.map(|v| PublishedFileId(v.published_file_id.0)))
+                    .collect::<Vec<_>>()
+            }))
+        })
     }
 }
 
@@ -905,7 +1061,7 @@ pub struct ItemListDetailsQuery<Manager> {
     // to prevent the handle from being dropped when this query is dropped.
     handle: Option<sys::UGCQueryHandle_t>,
 }
-impl <Manager> Drop for ItemListDetailsQuery<Manager> {
+impl<Manager> Drop for ItemListDetailsQuery<Manager> {
     fn drop(&mut self) {
         if let Some(handle) = self.handle.as_mut() {
             unsafe {
@@ -914,12 +1070,11 @@ impl <Manager> Drop for ItemListDetailsQuery<Manager> {
         }
     }
 }
-impl <Manager> ItemListDetailsQuery<Manager> {
+impl<Manager> ItemListDetailsQuery<Manager> {
     /// Sets how to match tags added by `require_tag`. If `true`, then any tag may match. If `false`, all required tags must match.
     pub fn any_required(self, any: bool) -> Self {
-        let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_SetMatchAnyTag(self.ugc, self.handle.unwrap(), any)
-        };
+        let ok =
+            unsafe { sys::SteamAPI_ISteamUGC_SetMatchAnyTag(self.ugc, self.handle.unwrap(), any) };
         debug_assert!(ok);
         self
     }
@@ -928,7 +1083,8 @@ impl <Manager> ItemListDetailsQuery<Manager> {
     ///
     /// Defaults to "english"
     pub fn language(self, language: &str) -> Self {
-        let cstr = CString::new(language).expect("String passed to language could not be converted to a c string");
+        let cstr = CString::new(language)
+            .expect("String passed to language could not be converted to a c string");
         let ok = unsafe {
             sys::SteamAPI_ISteamUGC_SetLanguage(self.ugc, self.handle.unwrap(), cstr.as_ptr())
         };
@@ -941,7 +1097,11 @@ impl <Manager> ItemListDetailsQuery<Manager> {
     /// Age is in seconds.
     pub fn allow_cached_response(self, max_age_s: u32) -> Self {
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_SetAllowCachedResponse(self.ugc, self.handle.unwrap(), max_age_s)
+            sys::SteamAPI_ISteamUGC_SetAllowCachedResponse(
+                self.ugc,
+                self.handle.unwrap(),
+                max_age_s,
+            )
         };
         debug_assert!(ok);
         self
@@ -950,7 +1110,11 @@ impl <Manager> ItemListDetailsQuery<Manager> {
     /// Include the full description in results
     pub fn include_long_desc(self, include: bool) -> Self {
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_SetReturnLongDescription(self.ugc, self.handle.unwrap(), include)
+            sys::SteamAPI_ISteamUGC_SetReturnLongDescription(
+                self.ugc,
+                self.handle.unwrap(),
+                include,
+            )
         };
         debug_assert!(ok);
         self
@@ -977,7 +1141,11 @@ impl <Manager> ItemListDetailsQuery<Manager> {
     /// Include additional previews in results
     pub fn include_additional_previews(self, include: bool) -> Self {
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_SetReturnAdditionalPreviews(self.ugc, self.handle.unwrap(), include)
+            sys::SteamAPI_ISteamUGC_SetReturnAdditionalPreviews(
+                self.ugc,
+                self.handle.unwrap(),
+                include,
+            )
         };
         debug_assert!(ok);
         self
@@ -994,7 +1162,8 @@ impl <Manager> ItemListDetailsQuery<Manager> {
 
     /// Runs the query
     pub fn fetch<F>(mut self, cb: F)
-        where F: for<'a> FnOnce(Result<QueryResults<'a>,SteamError>) + 'static + Send
+    where
+        F: for<'a> FnOnce(Result<QueryResults<'a>, SteamError>) + 'static + Send,
     {
         let ugc = self.ugc;
         let inner = Arc::clone(&self.inner);
@@ -1004,7 +1173,9 @@ impl <Manager> ItemListDetailsQuery<Manager> {
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_SendQueryUGCRequest(ugc, handle);
             register_call_result::<sys::SteamUGCQueryCompleted_t, _, _>(
-                &inner, api_call, CALLBACK_BASE_ID + 1,
+                &inner,
+                api_call,
+                CALLBACK_BASE_ID + 1,
                 move |v, io_error| {
                     let ugc = sys::SteamAPI_SteamUGC_v016();
                     if io_error {
@@ -1026,16 +1197,19 @@ impl <Manager> ItemListDetailsQuery<Manager> {
                         _phantom: Default::default(),
                     };
                     cb(Ok(result));
-            });
+                },
+            );
         }
     }
 
     /// Runs the query, only fetching the total number of results.
     pub fn fetch_total<F>(self, cb: F)
-        where F: Fn(Result<u32, SteamError>) + 'static + Send
+    where
+        F: Fn(Result<u32, SteamError>) + 'static + Send,
     {
         unsafe {
-            let ok = sys::SteamAPI_ISteamUGC_SetReturnTotalOnly(self.ugc, self.handle.unwrap(), true);
+            let ok =
+                sys::SteamAPI_ISteamUGC_SetReturnTotalOnly(self.ugc, self.handle.unwrap(), true);
             debug_assert!(ok);
         }
 
@@ -1052,7 +1226,7 @@ pub struct ItemDetailsQuery<Manager> {
     // to prevent the handle from being dropped when this query is dropped.
     handle: Option<sys::UGCQueryHandle_t>,
 }
-impl <Manager> Drop for ItemDetailsQuery<Manager> {
+impl<Manager> Drop for ItemDetailsQuery<Manager> {
     fn drop(&mut self) {
         if let Some(handle) = self.handle.as_mut() {
             unsafe {
@@ -1061,12 +1235,13 @@ impl <Manager> Drop for ItemDetailsQuery<Manager> {
         }
     }
 }
-impl <Manager> ItemDetailsQuery<Manager> {
+impl<Manager> ItemDetailsQuery<Manager> {
     /// Sets the language to return the title and description in for the items on a pending UGC Query.
     ///
     /// Defaults to "english"
     pub fn language(self, language: &str) -> Self {
-        let cstr = CString::new(language).expect("String passed to language could not be converted to a c string");
+        let cstr = CString::new(language)
+            .expect("String passed to language could not be converted to a c string");
         let ok = unsafe {
             sys::SteamAPI_ISteamUGC_SetLanguage(self.ugc, self.handle.unwrap(), cstr.as_ptr())
         };
@@ -1079,7 +1254,11 @@ impl <Manager> ItemDetailsQuery<Manager> {
     /// Age is in seconds.
     pub fn allow_cached_response(self, max_age_s: u32) -> Self {
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_SetAllowCachedResponse(self.ugc, self.handle.unwrap(), max_age_s)
+            sys::SteamAPI_ISteamUGC_SetAllowCachedResponse(
+                self.ugc,
+                self.handle.unwrap(),
+                max_age_s,
+            )
         };
         debug_assert!(ok);
         self
@@ -1088,7 +1267,11 @@ impl <Manager> ItemDetailsQuery<Manager> {
     /// Include the full description in results
     pub fn include_long_desc(self, include: bool) -> Self {
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_SetReturnLongDescription(self.ugc, self.handle.unwrap(), include)
+            sys::SteamAPI_ISteamUGC_SetReturnLongDescription(
+                self.ugc,
+                self.handle.unwrap(),
+                include,
+            )
         };
         debug_assert!(ok);
         self
@@ -1115,7 +1298,11 @@ impl <Manager> ItemDetailsQuery<Manager> {
     /// Include additional previews in results
     pub fn include_additional_previews(self, include: bool) -> Self {
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_SetReturnAdditionalPreviews(self.ugc, self.handle.unwrap(), include)
+            sys::SteamAPI_ISteamUGC_SetReturnAdditionalPreviews(
+                self.ugc,
+                self.handle.unwrap(),
+                include,
+            )
         };
         debug_assert!(ok);
         self
@@ -1123,7 +1310,8 @@ impl <Manager> ItemDetailsQuery<Manager> {
 
     /// Runs the query
     pub fn fetch<F>(mut self, cb: F)
-        where F: for<'a> FnOnce(Result<QueryResults<'a>,SteamError>) + 'static + Send
+    where
+        F: for<'a> FnOnce(Result<QueryResults<'a>, SteamError>) + 'static + Send,
     {
         let ugc = self.ugc;
         let inner = Arc::clone(&self.inner);
@@ -1133,7 +1321,9 @@ impl <Manager> ItemDetailsQuery<Manager> {
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_SendQueryUGCRequest(ugc, handle);
             register_call_result::<sys::SteamUGCQueryCompleted_t, _, _>(
-                &inner, api_call, CALLBACK_BASE_ID + 1,
+                &inner,
+                api_call,
+                CALLBACK_BASE_ID + 1,
                 move |v, io_error| {
                     let ugc = sys::SteamAPI_SteamUGC_v016();
                     if io_error {
@@ -1155,7 +1345,8 @@ impl <Manager> ItemDetailsQuery<Manager> {
                         _phantom: Default::default(),
                     };
                     cb(Ok(result));
-            });
+                },
+            );
         }
     }
 }
@@ -1197,7 +1388,13 @@ impl<'a> QueryResults<'a> {
         let mut url = [0 as c_char; 4096];
 
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_GetQueryUGCPreviewURL(self.ugc, self.handle, index, url.as_mut_ptr(), url.len() as _)
+            sys::SteamAPI_ISteamUGC_GetQueryUGCPreviewURL(
+                self.ugc,
+                self.handle,
+                index,
+                url.as_mut_ptr(),
+                url.len() as _,
+            )
         };
 
         if ok {
@@ -1216,7 +1413,13 @@ impl<'a> QueryResults<'a> {
         let mut value = 0u64;
 
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_GetQueryUGCStatistic(self.ugc, self.handle, index, stat_type.into(), &mut value)
+            sys::SteamAPI_ISteamUGC_GetQueryUGCStatistic(
+                self.ugc,
+                self.handle,
+                index,
+                stat_type.into(),
+                &mut value,
+            )
         };
 
         debug_assert!(ok);
@@ -1238,10 +1441,17 @@ impl<'a> QueryResults<'a> {
 
         unsafe {
             let mut raw_details: sys::SteamUGCDetails_t = mem::zeroed();
-            let ok = sys::SteamAPI_ISteamUGC_GetQueryUGCResult(self.ugc, self.handle, index, &mut raw_details);
+            let ok = sys::SteamAPI_ISteamUGC_GetQueryUGCResult(
+                self.ugc,
+                self.handle,
+                index,
+                &mut raw_details,
+            );
             debug_assert!(ok);
 
-            if raw_details.m_eResult != sys::EResult::k_EResultOK { return None }
+            if raw_details.m_eResult != sys::EResult::k_EResultOK {
+                return None;
+            }
 
             let tags = CStr::from_ptr(raw_details.m_rgchTags.as_ptr())
                 .to_string_lossy()
@@ -1251,8 +1461,16 @@ impl<'a> QueryResults<'a> {
 
             Some(QueryResult {
                 published_file_id: PublishedFileId(raw_details.m_nPublishedFileId),
-                creator_app_id: if raw_details.m_nCreatorAppID != 0 { Some(AppId(raw_details.m_nCreatorAppID)) } else { None },
-                consumer_app_id: if raw_details.m_nConsumerAppID != 0 { Some(AppId(raw_details.m_nConsumerAppID)) } else { None },
+                creator_app_id: if raw_details.m_nCreatorAppID != 0 {
+                    Some(AppId(raw_details.m_nCreatorAppID))
+                } else {
+                    None
+                },
+                consumer_app_id: if raw_details.m_nConsumerAppID != 0 {
+                    Some(AppId(raw_details.m_nConsumerAppID))
+                } else {
+                    None
+                },
                 title: CStr::from_ptr(raw_details.m_rgchTitle.as_ptr())
                     .to_string_lossy()
                     .into_owned(),
@@ -1280,9 +1498,8 @@ impl<'a> QueryResults<'a> {
     }
 
     /// Returns an iterator that runs over all the fetched results
-    pub fn iter<'b>(&'b self) -> impl Iterator<Item=Option<QueryResult>> + 'b {
-        (0..self.returned_results())
-            .map(move |i| self.get(i))
+    pub fn iter<'b>(&'b self) -> impl Iterator<Item = Option<QueryResult>> + 'b {
+        (0..self.returned_results()).map(move |i| self.get(i))
     }
 
     /// Returns the given index's children as a list of PublishedFileId.
@@ -1295,7 +1512,13 @@ impl<'a> QueryResults<'a> {
         let mut children: Vec<sys::PublishedFileId_t> = vec![0; num_children as usize];
 
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_GetQueryUGCChildren(self.ugc, self.handle, index, children.as_mut_ptr(), num_children)
+            sys::SteamAPI_ISteamUGC_GetQueryUGCChildren(
+                self.ugc,
+                self.handle,
+                index,
+                children.as_mut_ptr(),
+                num_children,
+            )
         };
 
         if ok {
@@ -1316,19 +1539,29 @@ impl<'a> QueryResults<'a> {
         let mut value = [0 as c_char; 256];
 
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_GetQueryUGCKeyValueTag(self.ugc, self.handle, index, kv_tag_index, key.as_mut_ptr(), 256, value.as_mut_ptr(), 256)
+            sys::SteamAPI_ISteamUGC_GetQueryUGCKeyValueTag(
+                self.ugc,
+                self.handle,
+                index,
+                kv_tag_index,
+                key.as_mut_ptr(),
+                256,
+                value.as_mut_ptr(),
+                256,
+            )
         };
 
         if ok {
-            Some(unsafe {(
-                CStr::from_ptr(key.as_ptr() as *const _)
-                    .to_string_lossy()
-                    .into_owned(),
-                
-                CStr::from_ptr(value.as_ptr() as *const _)
-                    .to_string_lossy()
-                    .into_owned()
-            )})
+            Some(unsafe {
+                (
+                    CStr::from_ptr(key.as_ptr() as *const _)
+                        .to_string_lossy()
+                        .into_owned(),
+                    CStr::from_ptr(value.as_ptr() as *const _)
+                        .to_string_lossy()
+                        .into_owned(),
+                )
+            })
         } else {
             None
         }
@@ -1341,7 +1574,13 @@ impl<'a> QueryResults<'a> {
         let mut metadata = [0 as c_char; sys::k_cchDeveloperMetadataMax as usize];
 
         let ok = unsafe {
-            sys::SteamAPI_ISteamUGC_GetQueryUGCMetadata(self.ugc, self.handle, index, metadata.as_mut_ptr(), sys::k_cchDeveloperMetadataMax)
+            sys::SteamAPI_ISteamUGC_GetQueryUGCMetadata(
+                self.ugc,
+                self.handle,
+                index,
+                metadata.as_mut_ptr(),
+                sys::k_cchDeveloperMetadataMax,
+            )
         };
 
         if ok {
@@ -1358,7 +1597,7 @@ impl<'a> QueryResults<'a> {
 }
 
 /// Query result
-#[derive(Debug,Clone)]
+#[derive(Debug, Clone)]
 pub struct QueryResult {
     pub published_file_id: PublishedFileId,
     pub creator_app_id: Option<AppId>,
@@ -1383,11 +1622,10 @@ pub struct QueryResult {
     /// The bayesian average for up votes / total votes, between \[0,1\].
     pub score: f32,
     pub num_children: u32,
-
     // TODO: Add missing fields as needed
 }
 
-#[derive(Debug,Clone,Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct CreateQueryError;
 impl fmt::Display for CreateQueryError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/user_stats.rs
+++ b/src/user_stats.rs
@@ -1,5 +1,5 @@
-pub mod stats;
 mod stat_callback;
+pub mod stats;
 
 pub use self::stat_callback::*;
 use super::*;
@@ -14,16 +14,21 @@ pub struct UserStats<Manager> {
 
 const CALLBACK_BASE_ID: i32 = 1100;
 
-impl <Manager> UserStats<Manager> {
-
+impl<Manager> UserStats<Manager> {
     pub fn find_leaderboard<F>(&self, name: &str, cb: F)
-        where F: FnOnce(Result<Option<Leaderboard>, SteamError>) + 'static + Send
+    where
+        F: FnOnce(Result<Option<Leaderboard>, SteamError>) + 'static + Send,
     {
         unsafe {
             let name = CString::new(name).unwrap();
-            let api_call = sys::SteamAPI_ISteamUserStats_FindLeaderboard(self.user_stats, name.as_ptr() as *const _);
+            let api_call = sys::SteamAPI_ISteamUserStats_FindLeaderboard(
+                self.user_stats,
+                name.as_ptr() as *const _,
+            );
             register_call_result::<sys::LeaderboardFindResult_t, _, _>(
-                &self.inner, api_call, CALLBACK_BASE_ID + 4,
+                &self.inner,
+                api_call,
+                CALLBACK_BASE_ID + 4,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -34,30 +39,54 @@ impl <Manager> UserStats<Manager> {
                             None
                         })
                     })
-            });
+                },
+            );
         }
     }
 
-    pub fn find_or_create_leaderboard<F>(&self, name: &str, sort_method: LeaderboardSortMethod, display_type: LeaderboardDisplayType, cb: F)
-        where F: FnOnce(Result<Option<Leaderboard>, SteamError>) + 'static + Send
+    pub fn find_or_create_leaderboard<F>(
+        &self,
+        name: &str,
+        sort_method: LeaderboardSortMethod,
+        display_type: LeaderboardDisplayType,
+        cb: F,
+    ) where
+        F: FnOnce(Result<Option<Leaderboard>, SteamError>) + 'static + Send,
     {
         unsafe {
             let name = CString::new(name).unwrap();
 
             let sort_method = match sort_method {
-                LeaderboardSortMethod::Ascending => sys::ELeaderboardSortMethod::k_ELeaderboardSortMethodAscending,
-                LeaderboardSortMethod::Descending => sys::ELeaderboardSortMethod::k_ELeaderboardSortMethodDescending,
+                LeaderboardSortMethod::Ascending => {
+                    sys::ELeaderboardSortMethod::k_ELeaderboardSortMethodAscending
+                }
+                LeaderboardSortMethod::Descending => {
+                    sys::ELeaderboardSortMethod::k_ELeaderboardSortMethodDescending
+                }
             };
 
             let display_type = match display_type {
-	            LeaderboardDisplayType::Numeric => sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeNumeric,
-	            LeaderboardDisplayType::TimeSeconds => sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeTimeSeconds,
-	            LeaderboardDisplayType::TimeMilliSeconds => sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeTimeMilliSeconds,
+                LeaderboardDisplayType::Numeric => {
+                    sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeNumeric
+                }
+                LeaderboardDisplayType::TimeSeconds => {
+                    sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeTimeSeconds
+                }
+                LeaderboardDisplayType::TimeMilliSeconds => {
+                    sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeTimeMilliSeconds
+                }
             };
 
-            let api_call = sys::SteamAPI_ISteamUserStats_FindOrCreateLeaderboard(self.user_stats, name.as_ptr() as *const _, sort_method, display_type);
+            let api_call = sys::SteamAPI_ISteamUserStats_FindOrCreateLeaderboard(
+                self.user_stats,
+                name.as_ptr() as *const _,
+                sort_method,
+                display_type,
+            );
             register_call_result::<sys::LeaderboardFindResult_t, _, _>(
-                &self.inner, api_call, CALLBACK_BASE_ID + 4,
+                &self.inner,
+                api_call,
+                CALLBACK_BASE_ID + 4,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -68,22 +97,42 @@ impl <Manager> UserStats<Manager> {
                             None
                         })
                     })
-                }
+                },
             );
         }
     }
 
-    pub fn upload_leaderboard_score<F>(&self, leaderboard: &Leaderboard, method: UploadScoreMethod, score: i32, details: &[i32], cb: F)
-        where F: FnOnce(Result<Option<LeaderboardScoreUploaded>, SteamError>) + 'static + Send
+    pub fn upload_leaderboard_score<F>(
+        &self,
+        leaderboard: &Leaderboard,
+        method: UploadScoreMethod,
+        score: i32,
+        details: &[i32],
+        cb: F,
+    ) where
+        F: FnOnce(Result<Option<LeaderboardScoreUploaded>, SteamError>) + 'static + Send,
     {
         unsafe {
             let method = match method {
-                UploadScoreMethod::KeepBest => sys::ELeaderboardUploadScoreMethod::k_ELeaderboardUploadScoreMethodKeepBest,
-                UploadScoreMethod::ForceUpdate => sys::ELeaderboardUploadScoreMethod::k_ELeaderboardUploadScoreMethodForceUpdate,
+                UploadScoreMethod::KeepBest => {
+                    sys::ELeaderboardUploadScoreMethod::k_ELeaderboardUploadScoreMethodKeepBest
+                }
+                UploadScoreMethod::ForceUpdate => {
+                    sys::ELeaderboardUploadScoreMethod::k_ELeaderboardUploadScoreMethodForceUpdate
+                }
             };
-            let api_call = sys::SteamAPI_ISteamUserStats_UploadLeaderboardScore(self.user_stats, leaderboard.0, method, score, details.as_ptr(), details.len() as _);
-            register_call_result::<sys::LeaderboardScoreUploaded_t , _, _>(
-                &self.inner, api_call, CALLBACK_BASE_ID + 6,
+            let api_call = sys::SteamAPI_ISteamUserStats_UploadLeaderboardScore(
+                self.user_stats,
+                leaderboard.0,
+                method,
+                score,
+                details.as_ptr(),
+                details.len() as _,
+            );
+            register_call_result::<sys::LeaderboardScoreUploaded_t, _, _>(
+                &self.inner,
+                api_call,
+                CALLBACK_BASE_ID + 6,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -99,40 +148,64 @@ impl <Manager> UserStats<Manager> {
                             None
                         })
                     })
-            });
+                },
+            );
         }
     }
 
     pub fn download_leaderboard_entries<F>(
         &self,
         leaderboard: &Leaderboard,
-        request: LeaderboardDataRequest, start: usize, end: usize,
+        request: LeaderboardDataRequest,
+        start: usize,
+        end: usize,
         max_details_len: usize,
-        cb: F
-    )
-        where F: FnOnce(Result<Vec<LeaderboardEntry>, SteamError>) + 'static + Send
+        cb: F,
+    ) where
+        F: FnOnce(Result<Vec<LeaderboardEntry>, SteamError>) + 'static + Send,
     {
         unsafe {
             let request = match request {
-                LeaderboardDataRequest::Global => sys::ELeaderboardDataRequest::k_ELeaderboardDataRequestGlobal,
-                LeaderboardDataRequest::GlobalAroundUser => sys::ELeaderboardDataRequest::k_ELeaderboardDataRequestGlobalAroundUser,
-                LeaderboardDataRequest::Friends => sys::ELeaderboardDataRequest::k_ELeaderboardDataRequestFriends,
+                LeaderboardDataRequest::Global => {
+                    sys::ELeaderboardDataRequest::k_ELeaderboardDataRequestGlobal
+                }
+                LeaderboardDataRequest::GlobalAroundUser => {
+                    sys::ELeaderboardDataRequest::k_ELeaderboardDataRequestGlobalAroundUser
+                }
+                LeaderboardDataRequest::Friends => {
+                    sys::ELeaderboardDataRequest::k_ELeaderboardDataRequestFriends
+                }
             };
-            let api_call = sys::SteamAPI_ISteamUserStats_DownloadLeaderboardEntries(self.user_stats, leaderboard.0, request, start as _, end as _);
+            let api_call = sys::SteamAPI_ISteamUserStats_DownloadLeaderboardEntries(
+                self.user_stats,
+                leaderboard.0,
+                request,
+                start as _,
+                end as _,
+            );
             let user_stats = self.user_stats as isize;
-            register_call_result::<sys::LeaderboardScoresDownloaded_t , _, _>(
-                &self.inner, api_call, CALLBACK_BASE_ID + 5,
+            register_call_result::<sys::LeaderboardScoresDownloaded_t, _, _>(
+                &self.inner,
+                api_call,
+                CALLBACK_BASE_ID + 5,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
                     } else {
                         let len = v.m_cEntryCount;
                         let mut entries = Vec::with_capacity(len as usize);
-                        for idx in 0 .. len {
+                        for idx in 0..len {
                             let mut entry: sys::LeaderboardEntry_t = std::mem::zeroed();
                             let mut details = Vec::with_capacity(max_details_len);
 
-                            sys::SteamAPI_ISteamUserStats_GetDownloadedLeaderboardEntry(user_stats as *mut _, v.m_hSteamLeaderboardEntries, idx, &mut entry, details.as_mut_ptr(), max_details_len as _);
+                            sys::SteamAPI_ISteamUserStats_GetDownloadedLeaderboardEntry(
+                                user_stats as *mut _,
+                                v.m_hSteamLeaderboardEntries,
+                                idx,
+                                &mut entry,
+                                details.as_mut_ptr(),
+                                max_details_len as _,
+                            );
                             details.set_len(entry.m_cDetails as usize);
 
                             entries.push(LeaderboardEntry {
@@ -144,29 +217,52 @@ impl <Manager> UserStats<Manager> {
                         }
                         Ok(entries)
                     })
-            });
+                },
+            );
         }
     }
 
     /// Returns the display type of a leaderboard handle. Returns `None` if the leaderboard handle is invalid.
-    pub fn get_leaderboard_display_type(&self, leaderboard: &Leaderboard) -> Option<LeaderboardDisplayType> {
+    pub fn get_leaderboard_display_type(
+        &self,
+        leaderboard: &Leaderboard,
+    ) -> Option<LeaderboardDisplayType> {
         unsafe {
-            match sys::SteamAPI_ISteamUserStats_GetLeaderboardDisplayType(self.user_stats, leaderboard.0) {
-                sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeNumeric => Some(LeaderboardDisplayType::Numeric),
-                sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeTimeSeconds => Some(LeaderboardDisplayType::TimeSeconds),
-                sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeTimeMilliSeconds => Some(LeaderboardDisplayType::TimeMilliSeconds),
-                _ => None
+            match sys::SteamAPI_ISteamUserStats_GetLeaderboardDisplayType(
+                self.user_stats,
+                leaderboard.0,
+            ) {
+                sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeNumeric => {
+                    Some(LeaderboardDisplayType::Numeric)
+                }
+                sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeTimeSeconds => {
+                    Some(LeaderboardDisplayType::TimeSeconds)
+                }
+                sys::ELeaderboardDisplayType::k_ELeaderboardDisplayTypeTimeMilliSeconds => {
+                    Some(LeaderboardDisplayType::TimeMilliSeconds)
+                }
+                _ => None,
             }
         }
     }
 
     /// Returns the sort method of a leaderboard handle. Returns `None` if the leaderboard handle is invalid.
-    pub fn get_leaderboard_sort_method(&self, leaderboard: &Leaderboard) -> Option<LeaderboardSortMethod> {
+    pub fn get_leaderboard_sort_method(
+        &self,
+        leaderboard: &Leaderboard,
+    ) -> Option<LeaderboardSortMethod> {
         unsafe {
-            match sys::SteamAPI_ISteamUserStats_GetLeaderboardSortMethod(self.user_stats, leaderboard.0) {
-                sys::ELeaderboardSortMethod::k_ELeaderboardSortMethodAscending => Some(LeaderboardSortMethod::Ascending),
-                sys::ELeaderboardSortMethod::k_ELeaderboardSortMethodDescending => Some(LeaderboardSortMethod::Descending),
-                _ => None
+            match sys::SteamAPI_ISteamUserStats_GetLeaderboardSortMethod(
+                self.user_stats,
+                leaderboard.0,
+            ) {
+                sys::ELeaderboardSortMethod::k_ELeaderboardSortMethodAscending => {
+                    Some(LeaderboardSortMethod::Ascending)
+                }
+                sys::ELeaderboardSortMethod::k_ELeaderboardSortMethodDescending => {
+                    Some(LeaderboardSortMethod::Descending)
+                }
+                _ => None,
             }
         }
     }
@@ -174,7 +270,10 @@ impl <Manager> UserStats<Manager> {
     /// Returns the name of a leaderboard handle. Returns an empty string if the leaderboard handle is invalid.
     pub fn get_leaderboard_name(&self, leaderboard: &Leaderboard) -> String {
         unsafe {
-            let name = CStr::from_ptr(sys::SteamAPI_ISteamUserStats_GetLeaderboardName(self.user_stats, leaderboard.0));
+            let name = CStr::from_ptr(sys::SteamAPI_ISteamUserStats_GetLeaderboardName(
+                self.user_stats,
+                leaderboard.0,
+            ));
             name.to_string_lossy().into()
         }
     }
@@ -188,7 +287,9 @@ impl <Manager> UserStats<Manager> {
 
     /// Triggers a [`UserStatsReceived`](./struct.UserStatsReceived.html) callback.
     pub fn request_current_stats(&self) {
-        unsafe { sys::SteamAPI_ISteamUserStats_RequestCurrentStats(self.user_stats); }
+        unsafe {
+            sys::SteamAPI_ISteamUserStats_RequestCurrentStats(self.user_stats);
+        }
     }
 
     /// Send the changed stats and achievements data to the server for permanent storage.
@@ -201,40 +302,63 @@ impl <Manager> UserStats<Manager> {
     /// and a successful [`UserStatsReceived`](./struct.UserStatsReceived.html) callback processed.
     pub fn store_stats(&self) -> Result<(), ()> {
         let success = unsafe { sys::SteamAPI_ISteamUserStats_StoreStats(self.user_stats) };
-        if success { Ok(()) } else { Err(()) }
+        if success {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 
-
     /// Sets / updates the value of a given stat for the current user
-    /// 
+    ///
     /// This call only changes the value in-memory and is very cheap. To commit the stats you
     /// must call [`store_stats()`](#method.store_stats)
-    /// 
+    ///
     /// The specified stat must exist and match the type set on the Steamworks App Admin website.
-    /// 
+    ///
     /// Requires [`request_current_stats()`](#method.request_current_stats) to have been called
     /// and a successful [`UserStatsReceived`](./struct.UserStatsReceived.html) callback processed.
     pub fn set_stat_i32(&self, name: &str, stat: i32) -> Result<(), ()> {
         let name = CString::new(name).unwrap();
 
-        let success = unsafe { sys::SteamAPI_ISteamUserStats_SetStatInt32(self.user_stats, name.as_ptr() as *const _, stat) };
-        if success { Ok(()) } else { Err(()) }
+        let success = unsafe {
+            sys::SteamAPI_ISteamUserStats_SetStatInt32(
+                self.user_stats,
+                name.as_ptr() as *const _,
+                stat,
+            )
+        };
+        if success {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 
     /// Sets / updates the value of a given stat for the current user
-    /// 
+    ///
     /// This call only changes the value in-memory and is very cheap. To commit the stats you
     /// must call [`store_stats()`](#method.store_stats)
-    /// 
+    ///
     /// The specified stat must exist and match the type set on the Steamworks App Admin website.
-    /// 
+    ///
     /// Requires [`request_current_stats()`](#method.request_current_stats) to have been called
     /// and a successful [`UserStatsReceived`](./struct.UserStatsReceived.html) callback processed.
     pub fn set_stat_f32(&self, name: &str, stat: f32) -> Result<(), ()> {
         let name = CString::new(name).unwrap();
 
-        let success = unsafe { sys::SteamAPI_ISteamUserStats_SetStatFloat(self.user_stats, name.as_ptr() as *const _, stat) };
-        if success { Ok(()) } else { Err(()) }
+        let success = unsafe {
+            sys::SteamAPI_ISteamUserStats_SetStatFloat(
+                self.user_stats,
+                name.as_ptr() as *const _,
+                stat,
+            )
+        };
+        if success {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 
     /// Access achievement API for a given achievement 'API Name'.
@@ -244,7 +368,10 @@ impl <Manager> UserStats<Manager> {
     #[inline]
     #[must_use]
     pub fn achievement(&self, name: &str) -> stats::AchievementHelper<'_, Manager> {
-        stats::AchievementHelper { name: CString::new(name).unwrap(), parent: self }
+        stats::AchievementHelper {
+            name: CString::new(name).unwrap(),
+            parent: self,
+        }
     }
 }
 
@@ -319,20 +446,38 @@ fn test() {
         println!("Got: {:?}", lb);
     });
     let c2 = client.clone();
-    stats.find_or_create_leaderboard("steamworks_test_created", LeaderboardSortMethod::Descending, LeaderboardDisplayType::TimeMilliSeconds, move |lb| {
-        println!("Got: {:?}", lb);
+    stats.find_or_create_leaderboard(
+        "steamworks_test_created",
+        LeaderboardSortMethod::Descending,
+        LeaderboardDisplayType::TimeMilliSeconds,
+        move |lb| {
+            println!("Got: {:?}", lb);
 
-        if let Some(lb) = lb.ok().and_then(|v| v) {
-            c2.user_stats().upload_leaderboard_score(&lb, UploadScoreMethod::ForceUpdate, 1337, &[1, 2, 3, 4], |v| {
-                println!("Upload: {:?}", v);
-            });
-            c2.user_stats().download_leaderboard_entries(&lb, LeaderboardDataRequest::Global, 0, 200, 10, |v| {
-                println!("Download: {:?}", v);
-            });
-        }
-    });
+            if let Some(lb) = lb.ok().and_then(|v| v) {
+                c2.user_stats().upload_leaderboard_score(
+                    &lb,
+                    UploadScoreMethod::ForceUpdate,
+                    1337,
+                    &[1, 2, 3, 4],
+                    |v| {
+                        println!("Upload: {:?}", v);
+                    },
+                );
+                c2.user_stats().download_leaderboard_entries(
+                    &lb,
+                    LeaderboardDataRequest::Global,
+                    0,
+                    200,
+                    10,
+                    |v| {
+                        println!("Download: {:?}", v);
+                    },
+                );
+            }
+        },
+    );
 
-    for _ in 0 .. 50 {
+    for _ in 0..50 {
         single.run_callbacks();
         ::std::thread::sleep(::std::time::Duration::from_millis(100));
     }

--- a/src/user_stats/stats.rs
+++ b/src/user_stats/stats.rs
@@ -38,7 +38,11 @@ impl<M> AchievementHelper<'_, M> {
                 self.name.as_ptr() as *const _,
                 &mut achieved as *mut _,
             );
-            if success { Ok(achieved) } else { Err(()) }
+            if success {
+                Ok(achieved)
+            } else {
+                Err(())
+            }
         }
     }
 
@@ -57,7 +61,11 @@ impl<M> AchievementHelper<'_, M> {
                 self.name.as_ptr() as *const _,
             )
         };
-        if success { Ok(()) } else { Err(()) }
+        if success {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 
     /// Resets the unlock status of an achievement.
@@ -75,6 +83,10 @@ impl<M> AchievementHelper<'_, M> {
                 self.name.as_ptr() as *const _,
             )
         };
-        if success { Ok(()) } else { Err(()) }
+        if success {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 }


### PR DESCRIPTION
This PR adds GitHub Actions that check the code format for `steamworks`, and set a rustfmt.toml to ignore `steamworks-sys`, as it's generated code. Also ran a `cargo fmt --all` over the codebase.