### PR TITLE
Add Steam server time function

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,9 +79,7 @@ impl<Manager> Utils<Manager> {
     /// Returns the current real time on the Steam servers
     /// in Unix epoch format (seconds since 1970/1/1 UTC).
     pub fn get_server_real_time(&self) -> u32 {
-        unsafe {
-            sys::SteamAPI_ISteamUtils_GetServerRealTime(self.utils)
-        }
+        unsafe { sys::SteamAPI_ISteamUtils_GetServerRealTime(self.utils) }
     }
 
     /// Sets the position on the screen where popups from the steam overlay

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -76,6 +76,14 @@ impl<Manager> Utils<Manager> {
         }
     }
 
+    /// Returns the current real time on the Steam servers
+    /// in Unix epoch format (seconds since 1970/1/1 UTC).
+    pub fn get_server_real_time(&self) -> u32 {
+        unsafe {
+            sys::SteamAPI_ISteamUtils_GetServerRealTime(self.utils)
+        }
+    }
+
     /// Sets the position on the screen where popups from the steam overlay
     /// should appear and display themselves in.
     pub fn set_overlay_notification_position(&self, position: NotificationPosition) {


### PR DESCRIPTION
This pull request adds a function `Utils::get_server_real_time() -> u32`. It's a very simple PR.

I needed this for Final Fantasy XIV stuff.