### PR TITLE
Release: v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "steamworks"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Thinkofname"]
 description = "Provides rust friendly bindings to the steamworks sdk"
 license = "MIT / Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/Noxime/steamworks-rs"
 documentation = "https://docs.rs/steamworks"
 keywords = ["steam", "gamedev"]
 categories = ["games"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []
@@ -28,5 +28,5 @@ lazy_static = "1.4.0"
 serde = { version = "1.0.123", features = ["derive"], optional = true }
 
 [dev-dependencies]
-serial_test = "0.5.1"
-serial_test_derive = "0.5.1"
+serial_test = "0.6"
+serial_test_derive = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ members = [
 ]
 
 [dependencies]
-steamworks-sys = {path = "./steamworks-sys", version = "0.8.0"}
-thiserror = "1.0.24"
-bitflags = "1.2.1"
-lazy_static = "1.4.0"
-serde = { version = "1.0.123", features = ["derive"], optional = true }
+steamworks-sys = {path = "./steamworks-sys", version = "0.9.0"}
+thiserror = "1.0"
+bitflags = "1.2"
+lazy_static = "1.4"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serial_test = "0.6"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-steamworks = "0.7.0"
+steamworks = "0.9.0"
 ```
 
 ## Example

--- a/steamworks-sys/Cargo.toml
+++ b/steamworks-sys/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "steamworks-sys"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Thinkofname"]
 build = "build.rs"
 description = "Provides raw bindings to the steamworks sdk"
 license = "MIT / Apache-2.0"
 repository = "https://github.com/Noxime/steamworks-rs"
 documentation = "https://docs.rs/steamworks-sys"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []


### PR DESCRIPTION
With the changes in how `steamworks-sys` is linked, and several other changes that had been introduced since the last version, it's probably time to release a new version of the crate.

In this PR:
 - Updated edition to 2021.
 - Bumped outdated dev-dependencies
 - Bumped crate version to v0.9.0.