### PR TITLE
Add missing UpdateHandle functions

### DIFF
--- a/src/remote_storage.rs
+++ b/src/remote_storage.rs
@@ -9,6 +9,37 @@ pub struct RemoteStorage<Manager> {
     pub(crate) inner: Arc<Inner<Manager>>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PublishedFileVisibility {
+    Public,
+    FriendsOnly,
+    Private,
+    Unlisted,
+}
+
+impl From<sys::ERemoteStoragePublishedFileVisibility> for PublishedFileVisibility {
+    fn from(visibility: sys::ERemoteStoragePublishedFileVisibility) -> Self {
+        match visibility {
+            sys::ERemoteStoragePublishedFileVisibility::k_ERemoteStoragePublishedFileVisibilityPublic => PublishedFileVisibility::Public,
+            sys::ERemoteStoragePublishedFileVisibility::k_ERemoteStoragePublishedFileVisibilityFriendsOnly => PublishedFileVisibility::FriendsOnly,
+            sys::ERemoteStoragePublishedFileVisibility::k_ERemoteStoragePublishedFileVisibilityPrivate => PublishedFileVisibility::Private,
+            sys::ERemoteStoragePublishedFileVisibility::k_ERemoteStoragePublishedFileVisibilityUnlisted => PublishedFileVisibility::Unlisted,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Into<sys::ERemoteStoragePublishedFileVisibility> for PublishedFileVisibility {
+    fn into(self) -> sys::ERemoteStoragePublishedFileVisibility {
+        match self {
+            PublishedFileVisibility::Public => sys::ERemoteStoragePublishedFileVisibility::k_ERemoteStoragePublishedFileVisibilityPublic,
+            PublishedFileVisibility::FriendsOnly => sys::ERemoteStoragePublishedFileVisibility::k_ERemoteStoragePublishedFileVisibilityFriendsOnly,
+            PublishedFileVisibility::Private => sys::ERemoteStoragePublishedFileVisibility::k_ERemoteStoragePublishedFileVisibilityPrivate,
+            PublishedFileVisibility::Unlisted => sys::ERemoteStoragePublishedFileVisibility::k_ERemoteStoragePublishedFileVisibilityUnlisted,
+        }
+    }
+}
+
 impl<Manager> Clone for RemoteStorage<Manager> {
     fn clone(&self) -> Self {
         RemoteStorage {

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -739,6 +739,19 @@ impl<Manager> UpdateHandle<Manager> {
         self
     }
 
+    #[must_use]
+    pub fn metadata(self, metadata: &str) -> Self {
+        unsafe {
+            let metadata = CString::new(metadata).unwrap();
+            assert!(sys::SteamAPI_ISteamUGC_SetItemMetadata(
+                self.ugc,
+                self.handle,
+                metadata.as_ptr()
+            ));
+        }
+        self
+    }
+
     pub fn visibility(self, visibility: remote_storage::PublishedFileVisibility) -> Self {
         unsafe {
             assert!(sys::SteamAPI_ISteamUGC_SetItemVisibility(

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -775,6 +775,42 @@ impl<Manager> UpdateHandle<Manager> {
         self
     }
 
+    pub fn add_key_value_tag(self, key: &str, value: &str) -> Self {
+        unsafe {
+            let key = CString::new(key).unwrap();
+            let value = CString::new(value).unwrap();
+            assert!(sys::SteamAPI_ISteamUGC_AddItemKeyValueTag(
+                self.ugc,
+                self.handle,
+                key.as_ptr(),
+                value.as_ptr()
+            ));
+        }
+        self
+    }
+
+    pub fn remove_key_value_tag(self, key: &str) -> Self {
+        unsafe {
+            let key = CString::new(key).unwrap();
+            assert!(sys::SteamAPI_ISteamUGC_RemoveItemKeyValueTags(
+                self.ugc,
+                self.handle,
+                key.as_ptr()
+            ));
+        }
+        self
+    }
+
+    pub fn remove_all_key_value_tags(self) -> Self {
+        unsafe {
+            assert!(sys::SteamAPI_ISteamUGC_RemoveAllItemKeyValueTags(
+                self.ugc,
+                self.handle
+            ));
+        }
+        self
+    }
+
     pub fn submit<F>(self, change_note: Option<&str>, cb: F) -> UpdateWatchHandle<Manager>
     where
         F: FnOnce(Result<(PublishedFileId, bool), SteamError>) + 'static + Send,

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -739,6 +739,17 @@ impl<Manager> UpdateHandle<Manager> {
         self
     }
 
+    pub fn visibility(self, visibility: remote_storage::PublishedFileVisibility) -> Self {
+        unsafe {
+            assert!(sys::SteamAPI_ISteamUGC_SetItemVisibility(
+                self.ugc,
+                self.handle,
+                visibility.into()
+            ));
+        }
+        self
+    }
+
     pub fn tags<S: AsRef<str>>(self, tags: Vec<S>) -> Self {
         unsafe {
             let mut tags = SteamParamStringArray::new(&tags);


### PR DESCRIPTION
This PR adds support for setting the visibility of uploaded UGC files. The newly implemented enum may find implementation in a couple more spots, though I didn't check that.