### PR TITLE
Misc changes to Input bindings.

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -43,7 +43,7 @@ impl<Manager> Input<Manager> {
     /// Returns a list of the currently connected controllers without allocating
     pub fn get_connected_controllers_slice(&self, mut controllers: impl AsMut<[InputHandle_t]>) {
         let handles = controllers.as_mut();
-        assert!(handles.len() <= sys::STEAM_INPUT_MAX_COUNT as usize);
+        assert!(handles.len() >= sys::STEAM_INPUT_MAX_COUNT as usize);
         unsafe {
             sys::SteamAPI_ISteamInput_GetConnectedControllers(self.input, handles.as_mut_ptr());
         }

--- a/src/input.rs
+++ b/src/input.rs
@@ -101,6 +101,15 @@ impl<Manager> Input<Manager> {
         }
     }
 
+    pub fn get_motion_data(
+        &self,
+        input_handle: sys::InputHandle_t,
+    ) -> sys::InputMotionData_t {
+        unsafe {
+            sys::SteamAPI_ISteamInput_GetMotionData(self.input, input_handle)
+        }
+    }
+
     /// Shutdown must be called when ending use of this interface.
     pub fn shutdown(&self) {
         unsafe {

--- a/src/input.rs
+++ b/src/input.rs
@@ -40,12 +40,12 @@ impl<Manager> Input<Manager> {
         }
     }
 
-    /// Returns a list of the currently connected controllers without allocating
-    pub fn get_connected_controllers_slice(&self, mut controllers: impl AsMut<[InputHandle_t]>) {
+    /// Returns a list of the currently connected controllers without allocating, and the count
+    pub fn get_connected_controllers_slice(&self, mut controllers: impl AsMut<[InputHandle_t]>) -> usize {
         let handles = controllers.as_mut();
         assert!(handles.len() >= sys::STEAM_INPUT_MAX_COUNT as usize);
         unsafe {
-            sys::SteamAPI_ISteamInput_GetConnectedControllers(self.input, handles.as_mut_ptr());
+            return sys::SteamAPI_ISteamInput_GetConnectedControllers(self.input, handles.as_mut_ptr()) as usize;
         }
     }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -41,11 +41,17 @@ impl<Manager> Input<Manager> {
     }
 
     /// Returns a list of the currently connected controllers without allocating, and the count
-    pub fn get_connected_controllers_slice(&self, mut controllers: impl AsMut<[InputHandle_t]>) -> usize {
+    pub fn get_connected_controllers_slice(
+        &self,
+        mut controllers: impl AsMut<[InputHandle_t]>,
+    ) -> usize {
         let handles = controllers.as_mut();
         assert!(handles.len() >= sys::STEAM_INPUT_MAX_COUNT as usize);
         unsafe {
-            return sys::SteamAPI_ISteamInput_GetConnectedControllers(self.input, handles.as_mut_ptr()) as usize;
+            return sys::SteamAPI_ISteamInput_GetConnectedControllers(
+                self.input,
+                handles.as_mut_ptr(),
+            ) as usize;
         }
     }
 
@@ -101,13 +107,8 @@ impl<Manager> Input<Manager> {
         }
     }
 
-    pub fn get_motion_data(
-        &self,
-        input_handle: sys::InputHandle_t,
-    ) -> sys::InputMotionData_t {
-        unsafe {
-            sys::SteamAPI_ISteamInput_GetMotionData(self.input, input_handle)
-        }
+    pub fn get_motion_data(&self, input_handle: sys::InputHandle_t) -> sys::InputMotionData_t {
+        unsafe { sys::SteamAPI_ISteamInput_GetMotionData(self.input, input_handle) }
     }
 
     /// Shutdown must be called when ending use of this interface.


### PR DESCRIPTION
I've split logical changes into their own commits but made a single PR in the interest of reducing PR spam.

The first commit is the most critical, it fixes a potential buffer overflow issue. I can only imagine that this was the intended behavior. I can split that out into a separate PR if the rest is not immediately ready to be accepted.