### PR TITLE
Some fixes for NetworkMessages API

### DIFF
--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -26,7 +26,7 @@
 use crate::networking_types::{
     NetConnectionInfo, NetworkingIdentity, NetworkingMessage, SendFlags,
 };
-use crate::{register_callback, Callback, Inner, SteamError};
+use crate::{register_callback, Callback, CallbackHandle, Inner, SteamError};
 use std::ffi::c_void;
 use std::sync::{Arc, Weak};
 
@@ -184,7 +184,7 @@ impl<Manager: 'static> NetworkingMessages<Manager> {
     pub fn session_request_callback(
         &self,
         mut callback: impl FnMut(SessionRequest<Manager>) + Send + 'static,
-    ) {
+    ) -> CallbackHandle<Manager> {
         let builder = SessionRequestBuilder {
             message: self.net,
             inner: Arc::downgrade(&self.inner),
@@ -197,7 +197,7 @@ impl<Manager: 'static> NetworkingMessages<Manager> {
                         callback(request);
                     }
                 },
-            );
+            )
         }
     }
 
@@ -208,14 +208,14 @@ impl<Manager: 'static> NetworkingMessages<Manager> {
     pub fn session_failed_callback(
         &self,
         mut callback: impl FnMut(NetConnectionInfo) + Send + 'static,
-    ) {
+    ) -> CallbackHandle<Manager> {
         unsafe {
             register_callback(
                 &self.inner,
                 move |failed: NetworkingMessagesSessionFailed| {
                     callback(failed.info);
                 },
-            );
+            )
         }
     }
 }

--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -275,7 +275,6 @@ unsafe impl Callback for NetworkingMessagesSessionFailed {
 /// A request for a new connection.
 ///
 /// Use this to accept or reject the connection.
-/// Letting this struct go out of scope will reject the connection.
 pub struct SessionRequest<Manager> {
     remote: NetworkingIdentity,
     messages: *mut sys::ISteamNetworkingMessages,
@@ -302,23 +301,12 @@ impl<Manager> SessionRequest<Manager> {
     }
 
     /// Reject the connection.
-    pub fn reject(mut self) {
-        self.reject_inner();
-    }
-
-    /// Reject the connection without consuming self, useful for implementing [`Drop`]
-    fn reject_inner(&mut self) {
+    pub fn reject(self) {
         unsafe {
             sys::SteamAPI_ISteamNetworkingMessages_CloseSessionWithUser(
                 self.messages,
                 self.remote.as_ptr(),
             );
         }
-    }
-}
-
-impl<Manager> Drop for SessionRequest<Manager> {
-    fn drop(&mut self) {
-        self.reject_inner();
     }
 }

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -673,13 +673,17 @@ pub enum NetConnectionEnd {
     // 1xxx: Application ended the connection in a "usual" manner.
     //       E.g.: user intentionally disconnected from the server,
     //             gameplay ended normally, etc
+    App(i32),
+    // Use this if you don't need application-specific end reason codes.
     AppGeneric,
 
     // 2xxx: Application ended the connection in some sort of exceptional
     //       or unusual manner that might indicate a bug or configuration
     //       issue.
     //
-    AppException,
+    AppException(i32),
+    // Use this if you don't need exceptional application-specific end reason codes.
+    AppExceptionGeneric,
 
     //
     // System codes.  These will be returned by the system when
@@ -823,7 +827,9 @@ impl From<NetConnectionEnd> for sys::ESteamNetConnectionEnd {
     fn from(end: NetConnectionEnd) -> Self {
         match end {
             NetConnectionEnd::AppGeneric => sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_App_Generic,
-            NetConnectionEnd::AppException => sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_AppException_Generic,
+            NetConnectionEnd::App(_) => sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_App_Generic,
+            NetConnectionEnd::AppExceptionGeneric => sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_AppException_Generic,
+            NetConnectionEnd::AppException(_) => sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_AppException_Generic,
             NetConnectionEnd::LocalOfflineMode => sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Local_OfflineMode,
             NetConnectionEnd::LocalManyRelayConnectivity => sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Local_ManyRelayConnectivity,
             NetConnectionEnd::LocalHostedServerPrimaryRelay => sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Local_HostedServerPrimaryRelay,
@@ -858,7 +864,9 @@ impl TryFrom<i32> for NetConnectionEnd {
     fn try_from(end: i32) -> Result<Self, Self::Error> {
         match end {
             end if end == sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_App_Generic as i32 => Ok(NetConnectionEnd::AppGeneric),
-            end if end == sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_AppException_Generic as i32 => Ok(NetConnectionEnd::AppException),
+            end if end > sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_App_Min as i32 && end < sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_App_Max as i32 => Ok(NetConnectionEnd::App(end)),
+            end if end == sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_AppException_Generic as i32 => Ok(NetConnectionEnd::AppExceptionGeneric),
+            end if end > sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_AppException_Min as i32 && end < sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_AppException_Max as i32 => Ok(NetConnectionEnd::AppException(end)),
             end if end == sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Local_OfflineMode as i32 => Ok(NetConnectionEnd::LocalOfflineMode),
             end if end == sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Local_ManyRelayConnectivity as i32 => Ok(NetConnectionEnd::LocalManyRelayConnectivity),
             end if end == sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Local_HostedServerPrimaryRelay as i32 => Ok(NetConnectionEnd::LocalHostedServerPrimaryRelay),
@@ -878,7 +886,7 @@ impl TryFrom<i32> for NetConnectionEnd {
             end if end == sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Misc_P2P_Rendezvous as i32 => Ok(NetConnectionEnd::MiscP2PRendezvous),
             end if end == sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Misc_P2P_NAT_Firewall as i32 => Ok(NetConnectionEnd::MiscP2PNATFirewall),
             end if end == sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Misc_PeerSentNoConnection as i32 => Ok(NetConnectionEnd::MiscPeerSentNoConnection),
-            _ => panic!("invalid connection end"),
+            _ => panic!("invalid connection end: {}", end),
         }
     }
 }
@@ -887,7 +895,7 @@ impl From<sys::ESteamNetConnectionEnd> for NetConnectionEnd {
     fn from(end: steamworks_sys::ESteamNetConnectionEnd) -> Self {
         match end {
             sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_App_Generic => NetConnectionEnd::AppGeneric,
-            sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_AppException_Generic => NetConnectionEnd::AppException,
+            sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_AppException_Generic => NetConnectionEnd::AppExceptionGeneric,
             sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Local_OfflineMode => NetConnectionEnd::LocalOfflineMode,
             sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Local_ManyRelayConnectivity => { NetConnectionEnd::LocalManyRelayConnectivity }
             sys::ESteamNetConnectionEnd::k_ESteamNetConnectionEnd_Local_HostedServerPrimaryRelay => { NetConnectionEnd::LocalHostedServerPrimaryRelay }


### PR DESCRIPTION
Return callbacks handles for session request/failed.

Remove drop impl for SessionRequest, this was causing all sessions to be rejected

Add user-defined NetConnectionEnd. User can define their application-specific errors from a range, but this was causing panics if used. I caught this because NetworkMessages define 2 errors in this range ([1001, 1002](https://github.com/ValveSoftware/GameNetworkingSockets/blob/e0d33386903202d9af61e76d69c54e46ece2f457/src/steamnetworkingsockets/clientlib/csteamnetworkingmessages.cpp#L33)), I'm not sure why they used this values that should be application-specific errors.