### PR TITLE
Add some missing ISteamUtils functions required for the Steam Deck

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -220,17 +220,16 @@ impl<Manager> Utils<Manager> {
     /// `GamepadTextInputDismissed_t::m_bSubmitted` is true.
     ///
     /// Provides the text input as UTF-8.
-    pub fn get_entered_gamepad_text_input(&self) -> Option<String> {
+    pub fn get_entered_gamepad_text_input(&self, length: usize) -> Option<String> {
         unsafe {
-            let mut buf = [0u8; 1024];
-            let len = 0;
+            let mut buf = vec![0u8; length];
             let res = sys::SteamAPI_ISteamUtils_GetEnteredGamepadTextInput(
                 self.utils,
                 buf.as_mut_ptr() as *mut i8,
                 buf.len() as u32,
             );
             if res {
-                Some(String::from_utf8_lossy(&buf[..len as usize]).into_owned())
+                Some(String::from_utf8_lossy(&buf[..length]).into_owned())
             } else {
                 None
             }


### PR DESCRIPTION
I added some missing ISteamUtils functions required for the Steam Deck:
* IsSteamRunningOnSteamDeck
* GetEnteredGamepadTextInput
* GetEnteredGamepadTextLength
* ShowGamepadTextInput
* ShowFloatingGamepadTextInput

I haven't tested these yet, so I'd appreciate it if @gemdude46 could test them, since they asked for them in #118 . Especially `GetEnteredGamepadTextInput`, since it requires to be called in a specific callback (`GamepadTextInputDismissed_t` and I presume `FloatingGamepadTextInputDismissed_t` has that requirement too).

For ease of use, I added callback parameters to `show_gamepad_text_input` and `show_floating_gamepad_text_input` which trigger respectively when the gamepads have been dismissed, that should make it safe to get the text inside those callbacks.