### PR TITLE
Add method GetConnectionInfo

### DIFF
--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -994,7 +994,7 @@ pub struct InvalidEnumValue;
 /// Internal struct to handle network callbacks
 #[derive(Clone)]
 pub struct NetConnectionInfo {
-    inner: sys::SteamNetConnectionInfo_t,
+    pub(crate) inner: sys::SteamNetConnectionInfo_t,
 }
 
 #[allow(dead_code)]

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1063,10 +1063,6 @@ impl From<sys::SteamNetConnectionInfo_t> for NetConnectionInfo {
     }
 }
 
-/// This in an internal callback that will be used by Steam Networking Sockets directly.
-/// It should not be created manually.
-///
-///
 /// This callback is posted whenever a connection is created, destroyed, or changes state.
 /// The m_info field will contain a complete description of the connection at the time the
 /// change occurred and the callback was posted.  In particular, m_eState will have the
@@ -1103,13 +1099,13 @@ impl From<sys::SteamNetConnectionInfo_t> for NetConnectionInfo {
 ///
 /// Also note that callbacks will be posted when connections are created and destroyed by your own API calls.
 #[derive(Debug, Clone)]
-pub(crate) struct NetConnectionStatusChanged {
+pub struct NetConnectionStatusChanged {
     pub(crate) connection: sys::HSteamNetConnection,
-    pub(crate) connection_info: NetConnectionInfo,
+    pub connection_info: NetConnectionInfo,
 
     // Debug is intentionally ignored during dead-code analysis
     #[allow(dead_code)]
-    pub(crate) old_state: NetworkingConnectionState,
+    pub old_state: NetworkingConnectionState,
 }
 
 unsafe impl Callback for NetConnectionStatusChanged {

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1100,11 +1100,15 @@ impl From<sys::SteamNetConnectionInfo_t> for NetConnectionInfo {
 /// Also note that callbacks will be posted when connections are created and destroyed by your own API calls.
 #[derive(Debug, Clone)]
 pub struct NetConnectionStatusChanged {
+    /// The handle of the connection that has changed state
+    // (only important for the ListenSocketEvent, so it can stay for now in the crate visibility)
     pub(crate) connection: sys::HSteamNetConnection,
+    /// Full connection info
     pub connection_info: NetConnectionInfo,
 
     // Debug is intentionally ignored during dead-code analysis
     #[allow(dead_code)]
+    /// Previous state.  (Current state is in m_info.m_eState)
     pub old_state: NetworkingConnectionState,
 }
 


### PR DESCRIPTION
This pr fixes #133.

The goal of this PR is to get a way to identify if a NetworkConnection is still valid and to get its connection state.

**Motivation**

As a user or server/host i want to be able to know in which state the connection is, so that i can react on this changes.

**Example**

In Bevy i only want to run the systems for a connecting state when im in the connection state like a loading screen.
And also systems for Connecting and Disconnecting.

**Tasks**

- [x]  Implement [ConnectionInfo](https://partner.steamgames.com/doc/api/ISteamNetworkingSockets#functions_connection_info) methods
- [x]  Make [NetConnectionStatusChanged ](https://partner.steamgames.com/doc/api/ISteamNetworkingSockets#SteamNetConnectionStatusChangedCallback_t) public 

