### PR TITLE
add clone and debug to more callbacks

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -175,6 +175,7 @@ pub struct AuthTicket(pub(crate) sys::HAuthTicket);
 /// Called when generating a authentication session ticket.
 ///
 /// This can be used to verify the ticket was created successfully.
+#[derive(Clone, Debug)]
 pub struct AuthSessionTicketResponse {
     /// The ticket in question
     pub ticket: AuthTicket,
@@ -201,7 +202,7 @@ unsafe impl Callback for AuthSessionTicketResponse {
 
 /// Called when an authentication ticket has been
 /// validated.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ValidateAuthTicketResponse {
     /// The steam id of the entity that provided the ticket
     pub steam_id: SteamId,
@@ -337,7 +338,7 @@ unsafe impl Callback for SteamServerConnectFailure {
 }
 
 /// Errors from `ValidateAuthTicketResponse`
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 pub enum AuthSessionValidateError {
     /// The user in question is not connected to steam
     #[error("user not connected to steam")]

--- a/src/user_stats/stat_callback.rs
+++ b/src/user_stats/stat_callback.rs
@@ -14,7 +14,7 @@ use super::*;
 ///     }
 /// });
 /// ```
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct UserStatsReceived {
     pub steam_id: SteamId,
     pub game_id: GameId,
@@ -51,7 +51,7 @@ unsafe impl Callback for UserStatsReceived {
 ///     }
 /// });
 /// ```
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct UserStatsStored {
     pub game_id: GameId,
     pub result: Result<(), SteamError>,
@@ -86,7 +86,7 @@ unsafe impl Callback for UserStatsStored {
 ///     // ...
 /// });
 /// ```
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct UserAchievementStored {
     pub game_id: GameId,
     pub achievement_name: String,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,6 +12,7 @@ pub struct Utils<Manager> {
     pub(crate) _inner: Arc<Inner<Manager>>,
 }
 
+#[derive(Clone, Debug)]
 pub struct GamepadTextInputDismissed {
     pub submitted_text_len: Option<u32>,
 }
@@ -28,6 +29,7 @@ unsafe impl Callback for GamepadTextInputDismissed {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct FloatingGamepadTextInputDismissed;
 
 unsafe impl Callback for FloatingGamepadTextInputDismissed {


### PR DESCRIPTION
In order to integrate steamworks-rs with iced-rs, the steam callbacks need to derive both Debug and Clone in order to be injected into Iced's ecosystem as Messages.  I noticed that 5 out of the 14 callbacks I was using were either missing Debug, Clone, or both.  I went through and added Debug and Clone to some more callbacks.  I didn't touch the network ones though, those went really deep all the way into the OS bindings.