### PR TITLE
Implement wrapper for SendLobbyChatMsg

### DIFF
--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -270,7 +270,7 @@ impl<Manager> Matchmaking<Manager> {
         unsafe { sys::SteamAPI_ISteamMatchmaking_SetLobbyJoinable(self.mm, lobby.0, joinable) }
     }
 
-    pub fn send_lobby_chat_message(&self, lobby: LobbyId, msg: Vec<u8>) {
+    pub fn send_lobby_chat_message(&self, lobby: LobbyId, msg: &[u8]) {
         unsafe {
             steamworks_sys::SteamAPI_ISteamMatchmaking_SendLobbyChatMsg(
                 self.mm,

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -124,9 +124,7 @@ impl<Manager> Matchmaking<Manager> {
                 api_call,
                 CALLBACK_BASE_ID + 4,
                 move |v, io_error| {
-                    cb(if io_error {
-                        Err(())
-                    } else if v.m_EChatRoomEnterResponse != 1 {
+                    cb(if io_error || v.m_EChatRoomEnterResponse != 1 {
                         Err(())
                     } else {
                         Ok(LobbyId(v.m_ulSteamIDLobby))
@@ -270,6 +268,17 @@ impl<Manager> Matchmaking<Manager> {
     /// Returns true on success, false if the current user doesn't own the lobby.
     pub fn set_lobby_joinable(&self, lobby: LobbyId, joinable: bool) -> bool {
         unsafe { sys::SteamAPI_ISteamMatchmaking_SetLobbyJoinable(self.mm, lobby.0, joinable) }
+    }
+
+    pub fn send_lobby_chat_message(&mut self, lobby: LobbyId, msg: Vec<u8>) {
+        unsafe {
+            steamworks_sys::SteamAPI_ISteamMatchmaking_SendLobbyChatMsg(
+                self.mm,
+                lobby.0,
+                msg.as_ptr() as *const c_void,
+                msg.len() as i32,
+            );
+        }
     }
 }
 

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -270,7 +270,7 @@ impl<Manager> Matchmaking<Manager> {
         unsafe { sys::SteamAPI_ISteamMatchmaking_SetLobbyJoinable(self.mm, lobby.0, joinable) }
     }
 
-    pub fn send_lobby_chat_message(&mut self, lobby: LobbyId, msg: Vec<u8>) {
+    pub fn send_lobby_chat_message(&self, lobby: LobbyId, msg: Vec<u8>) {
         unsafe {
             steamworks_sys::SteamAPI_ISteamMatchmaking_SendLobbyChatMsg(
                 self.mm,


### PR DESCRIPTION
closes #137

summary:
* renamed SendLobbyChatMsg to `send_lobby_chat_message`
* changed the return type from `bool` to `Result<(), SteamError>
* added documentation adapted from the steamworks docs page
* fixed an error regarding an unrelated if statement (feel free to revert)