### PR TITLE
Add lobby list request filtering

### DIFF
--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -319,7 +319,7 @@ impl<Manager> Matchmaking<Manager> {
     /// * `key`: The attribute key to compare.
     /// * `value`: The value to compare against.
     ///
-    pub fn set_request_lobby_list_string_filter(
+    pub fn add_request_lobby_list_string_filter(
         &self,
         StringFilter(key, value): StringFilter,
     ) -> &Self {
@@ -343,7 +343,7 @@ impl<Manager> Matchmaking<Manager> {
     /// * `key`: The attribute key to compare.
     /// * `value`: The value to compare against.
     ///
-    pub fn set_request_lobby_list_numerical_filter(
+    pub fn add_request_lobby_list_numerical_filter(
         &self,
         NumberFilter(key, value, comparison): NumberFilter,
     ) -> &Self {
@@ -367,7 +367,7 @@ impl<Manager> Matchmaking<Manager> {
     /// * `key`: The attribute key to use for sorting.
     /// * `value`: The reference value for sorting.
     ///
-    pub fn set_request_lobby_list_near_value_filter(
+    pub fn add_request_lobby_list_near_value_filter(
         &self,
         NearFilter(key, value): NearFilter,
     ) -> &Self {
@@ -476,7 +476,7 @@ impl<Manager> Matchmaking<Manager> {
             .into_iter()
             .map(Clone::clone)
             .for_each(|str_filter| {
-                self.set_request_lobby_list_string_filter(str_filter);
+                self.add_request_lobby_list_string_filter(str_filter);
             });
         filter
             .number
@@ -485,7 +485,7 @@ impl<Manager> Matchmaking<Manager> {
             .into_iter()
             .map(Clone::clone)
             .for_each(|num_filter| {
-                self.set_request_lobby_list_numerical_filter(num_filter);
+                self.add_request_lobby_list_numerical_filter(num_filter);
             });
         filter
             .near_value
@@ -494,7 +494,7 @@ impl<Manager> Matchmaking<Manager> {
             .into_iter()
             .map(|value| *value)
             .for_each(|near_filter| {
-                self.set_request_lobby_list_near_value_filter(near_filter);
+                self.add_request_lobby_list_near_value_filter(near_filter);
             });
         if let Some(distance) = filter.distance {
             self.set_request_lobby_list_distance_filter(distance);

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -493,19 +493,19 @@ impl<Manager> Matchmaking<Manager> {
 pub struct LobbyListFilter<'a> {
     /// A string comparison filter that matches lobby attributes with specific strings.
     #[cfg_attr(feature = "serde", serde(borrow))]
-    string: Option<(&'a str, &'a str)>,
+    pub string: Option<(&'a str, &'a str)>,
     /// A number comparison filter that matches lobby attributes with specific integer values
     #[cfg_attr(feature = "serde", serde(borrow))]
-    number: Option<(&'a str, i32)>,
+    pub number: Option<(&'a str, i32)>,
     /// Specifies a value, and the results will be sorted closest to this value (no actual filtering)
     #[cfg_attr(feature = "serde", serde(borrow))]
-    near_value: Option<(&'a str, i32)>,
+    pub near_value: Option<(&'a str, i32)>,
     /// Filters lobbies based on the number of open slots they have
-    open_slots: Option<u8>,
+    pub open_slots: Option<u8>,
     /// Filters lobbies based on a distance criterion
-    distance: Option<DistanceFilter>,
+    pub distance: Option<DistanceFilter>,
     /// Specifies the maximum number of lobby results to be returned
-    count: Option<u64>,
+    pub count: Option<u64>,
 }
 
 impl<'a> LobbyListFilter<'a> {

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -319,7 +319,7 @@ impl<Manager> Matchmaking<Manager> {
     /// * `key`: The attribute key to compare.
     /// * `value`: The value to compare against.
     ///
-    pub fn set_request_lobby_list_string_filter(&self, key: &str, value: &str) {
+    pub fn set_request_lobby_list_string_filter(&self, key: &str, value: &str) -> &Self {
         unsafe {
             sys::SteamAPI_ISteamMatchmaking_AddRequestLobbyListStringFilter(
                 self.mm,
@@ -328,6 +328,7 @@ impl<Manager> Matchmaking<Manager> {
                 sys::ELobbyComparison::k_ELobbyComparisonEqual,
             );
         }
+        self
     }
     /// Adds a numerical comparison filter to the lobby list request.
     ///
@@ -339,7 +340,7 @@ impl<Manager> Matchmaking<Manager> {
     /// * `key`: The attribute key to compare.
     /// * `value`: The value to compare against.
     ///
-    pub fn set_request_lobby_list_numerical_filter(&self, key: &str, value: i32) {
+    pub fn set_request_lobby_list_numerical_filter(&self, key: &str, value: i32) -> &Self {
         unsafe {
             sys::SteamAPI_ISteamMatchmaking_AddRequestLobbyListNumericalFilter(
                 self.mm,
@@ -348,6 +349,7 @@ impl<Manager> Matchmaking<Manager> {
                 sys::ELobbyComparison::k_ELobbyComparisonEqual,
             );
         }
+        self
     }
     /// Adds a near value filter to the lobby list request.
     ///
@@ -359,7 +361,7 @@ impl<Manager> Matchmaking<Manager> {
     /// * `key`: The attribute key to use for sorting.
     /// * `value`: The reference value for sorting.
     ///
-    pub fn set_request_lobby_list_near_value_filter(&self, key: &str, value: i32) {
+    pub fn set_request_lobby_list_near_value_filter(&self, key: &str, value: i32) -> &Self {
         unsafe {
             sys::SteamAPI_ISteamMatchmaking_AddRequestLobbyListNearValueFilter(
                 self.mm,
@@ -367,6 +369,7 @@ impl<Manager> Matchmaking<Manager> {
                 value,
             );
         }
+        self
     }
     /// Adds a filter for available open slots to the lobby list request.
     ///
@@ -376,13 +379,14 @@ impl<Manager> Matchmaking<Manager> {
     ///
     /// * `open_slots`: The number of open slots in a lobby to filter by.
     ///
-    pub fn set_request_lobby_list_slots_available_filter(&self, open_slots: u8) {
+    pub fn set_request_lobby_list_slots_available_filter(&self, open_slots: u8) -> &Self {
         unsafe {
             sys::SteamAPI_ISteamMatchmaking_AddRequestLobbyListFilterSlotsAvailable(
                 self.mm,
                 open_slots as i32,
             );
         }
+        self
     }
     /// Adds a distance filter to the lobby list request.
     ///
@@ -392,13 +396,14 @@ impl<Manager> Matchmaking<Manager> {
     ///
     /// * `distance`: The `DistanceFilter` indicating the distance criterion for the filter.
     ///
-    pub fn set_request_lobby_list_distance_filter(&self, distance: DistanceFilter) {
+    pub fn set_request_lobby_list_distance_filter(&self, distance: DistanceFilter) -> &Self {
         unsafe {
             sys::SteamAPI_ISteamMatchmaking_AddRequestLobbyListDistanceFilter(
                 self.mm,
                 distance.into(),
             );
         }
+        self
     }
     /// Adds a result count filter to the lobby list request.
     ///
@@ -408,13 +413,14 @@ impl<Manager> Matchmaking<Manager> {
     ///
     /// * `count`: The maximum number of lobby results to include in the response.
     ///
-    pub fn set_request_lobby_list_result_count_filter(&self, count: u64) {
+    pub fn set_request_lobby_list_result_count_filter(&self, count: u64) -> &Self {
         unsafe {
             sys::SteamAPI_ISteamMatchmaking_AddRequestLobbyListResultCountFilter(
                 self.mm,
                 count as i32,
             );
         }
+        self
     }
 
     /// Sets filters for the lobbies to be returned from [`request_lobby_list`].

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -489,6 +489,7 @@ impl<Manager> Matchmaking<Manager> {
 /// - `distance`: Filters lobbies based on a distance criterion.
 /// - `count`: Specifies the maximum number of lobby results to be returned.
 #[derive(Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LobbyListFilter<'a> {
     /// A string comparison filter that matches lobby attributes with specific strings.
     string: Option<(&'a str, &'a str)>,
@@ -568,6 +569,7 @@ impl<'a> LobbyListFilter<'a> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DistanceFilter {
     Close,
     #[default]

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -492,10 +492,13 @@ impl<Manager> Matchmaking<Manager> {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LobbyListFilter<'a> {
     /// A string comparison filter that matches lobby attributes with specific strings.
+    #[cfg_attr(feature = "serde", serde(borrow))]
     string: Option<(&'a str, &'a str)>,
     /// A number comparison filter that matches lobby attributes with specific integer values
+    #[cfg_attr(feature = "serde", serde(borrow))]
     number: Option<(&'a str, i32)>,
     /// Specifies a value, and the results will be sorted closest to this value (no actual filtering)
+    #[cfg_attr(feature = "serde", serde(borrow))]
     near_value: Option<(&'a str, i32)>,
     /// Filters lobbies based on the number of open slots they have
     open_slots: Option<u8>,


### PR DESCRIPTION
closes #140 
# Summary
added 7 functions for filtering out lobby requests:
* `set_lobby_list_filter`: adds filters defined in a `LobbyListFilter` struct.
* `set_request_lobby_list_string_filter`: adds filters for key value pairs of strings.
* `set_request_lobby_list_numerical_filter`: adds filters for key value pairs of string number types.
* `set_request_lobby_list_near_value_filter`: adds sorting based on which value is closer to the filter
* `set_request_lobby_list_distance_filter`: adds filtering based on geographical distance
* `set_request_lobby_list_slots_available_filter`: adds filtering based on how many open slots a lobby has
* `set_request_lobby_list_result_count_filter`: adds the maximum number of results a request can resolve to.

added 1 struct:
* `LobbyListFilter`: struct that holds every option possible for filtering

added 1 enum: 
* `DistanceFilter`: thin wrapper over `ELobbyDistanceFilter`
I included documentation for everything I added and one code example. 