### PR TITLE
Add extra derive bounds to ServerMode

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -17,7 +17,9 @@ pub struct Server {
 unsafe impl Send for Server {}
 unsafe impl Sync for Server {}
 
+
 /// Used to set the mode that a gameserver will run in
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ServerMode {
     /// Don't authenticate user logins.
     ///

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,7 +17,6 @@ pub struct Server {
 unsafe impl Send for Server {}
 unsafe impl Sync for Server {}
 
-
 /// Used to set the mode that a gameserver will run in
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ServerMode {


### PR DESCRIPTION
This would be useful for me, as I include `ServerMode` in a `Config` object that derives those traits