### PR TITLE
Change NetConnectionEnd to be closer to ESteamNetConnectionEnd

### DIFF
--- a/src/networking_sockets.rs
+++ b/src/networking_sockets.rs
@@ -17,6 +17,7 @@ use std::sync::mpsc::Receiver;
 use std::sync::Arc;
 use sys::SteamNetworkingMessage_t;
 
+use crate::networking_types::AppNetConnectionEnd;
 use steamworks_sys as sys;
 
 /// Access to the steam networking sockets interface
@@ -948,7 +949,7 @@ impl<Manager> Drop for NetConnection<Manager> {
                 sys::SteamAPI_ISteamNetworkingSockets_CloseConnection(
                     self.sockets,
                     self.handle,
-                    NetConnectionEnd::AppGeneric.into(),
+                    NetConnectionEnd::App(AppNetConnectionEnd::generic_normal()).into(),
                     debug_string.as_ptr(),
                     false,
                 )

--- a/src/networking_sockets_callback.rs
+++ b/src/networking_sockets_callback.rs
@@ -1,6 +1,6 @@
 use crate::networking_sockets::NetConnection;
 use crate::networking_types::{
-    NetConnectionEnd, NetConnectionStatusChanged, NetworkingConnectionState,
+    AppNetConnectionEnd, NetConnectionEnd, NetConnectionStatusChanged, NetworkingConnectionState,
 };
 use crate::{register_callback, CallbackHandle, Inner};
 use std::sync::{Arc, Weak};
@@ -83,7 +83,7 @@ impl<Manager: 'static> ConnectionCallbackHandler<Manager> {
     fn reject_connection(&self, connection_handle: sys::HSteamNetConnection) {
         if let Some(inner) = self.inner.upgrade() {
             NetConnection::new_internal(connection_handle, self.sockets, inner.clone()).close(
-                NetConnectionEnd::AppGeneric,
+                NetConnectionEnd::App(AppNetConnectionEnd::generic_normal()).into(),
                 Some("no new connections will be accepted"),
                 false,
             );


### PR DESCRIPTION
I encountered a problem where sometimes my server would panic for no apparent reason. 

The panic happened in TryFrom<i32> for NetConnectionEnd. I'm not quite sure why I added a panic in a `try_from` implementation in my original PR. I think that was simply an oversight on my part.

After looking at NetConnectionEnd again it seemed like a better idea to create a fallback `Other` type in case new types get added in the future. I also made it possible to customize app end reasons.