### PR TITLE
Add file_name field to QueryResult.

### DIFF
--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -1661,6 +1661,9 @@ impl<'a> QueryResults<'a> {
                 num_children: raw_details.m_unNumChildren,
                 tags,
                 tags_truncated: raw_details.m_bTagsTruncated,
+                file_name: CStr::from_ptr(raw_details.m_pchFileName.as_ptr())
+                    .to_string_lossy()
+                    .into_owned(),
                 file_type: raw_details.m_eFileType.into(),
                 file_size: raw_details.m_nFileSize.max(0) as u32,
             })
@@ -1786,6 +1789,8 @@ pub struct QueryResult {
     pub accepted_for_use: bool,
     pub tags: Vec<String>,
     pub tags_truncated: bool,
+    /// Original file name of the workshop item. Used in old games, like Total War: Shogun 2.
+    pub file_name: String,
     pub file_type: FileType,
     pub file_size: u32,
 


### PR DESCRIPTION
This adds the "file_name" field to QueryResult. 

AFAIK, this field is empty in modern games, but it's needed to manage workshop items in older games.

For example, in Total War: Shogun 2, mods are ".pack" files. When uploaded, they get wrapped into a ".bin" file with a random name. When you subscribe to them, the ".bin" file is downloaded, and you need this field to know what the original name of the file was.