### PR TITLE
feat(friends): adding getFriendsFromSource & avatar wrappers

### DIFF
--- a/src/friends.rs
+++ b/src/friends.rs
@@ -111,6 +111,31 @@ impl<Manager> Friends<Manager> {
             friends
         }
     }
+
+    /// Get a list of users from a specific source (e.g. gameserver)
+    /// Despite the misleading name, it does not return only friends
+    /// but all users from the source that are currently connected.
+    /// This does however require some local client to be connected to the source.
+    pub fn get_friends_from_source(&self, source: SteamId) -> Vec<Friend<Manager>> {
+        unsafe {
+            let count =
+                sys::SteamAPI_ISteamFriends_GetFriendCountFromSource(self.friends, source.0);
+            if count == -1 {
+                return Vec::new();
+            }
+            let mut friends = Vec::with_capacity(count as usize);
+            for idx in 0..count {
+                let friend = SteamId(sys::SteamAPI_ISteamFriends_GetFriendFromSourceByIndex(
+                    self.friends,
+                    source.0,
+                    idx,
+                ));
+                friends.push(self.get_friend(friend));
+            }
+            friends
+        }
+    }
+
     /// Returns recently played with players list
     pub fn get_coplay_friends(&self) -> Vec<Friend<Manager>> {
         unsafe {

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -92,6 +92,82 @@ impl<Manager> Friends<Manager> {
         }
     }
 
+    /// Returns a small (32x32) avatar for the current user in RGBA format
+    pub fn small_avatar(&self) -> Option<Vec<u8>> {
+        unsafe {
+            let user: *mut sys::ISteamUser = sys::SteamAPI_SteamUser_v023();
+            let steam_id = sys::SteamAPI_ISteamUser_GetSteamID(user);
+            let utils = sys::SteamAPI_SteamUtils_v010();
+            let img = sys::SteamAPI_ISteamFriends_GetSmallFriendAvatar(self.friends, steam_id);
+            if img == 0 {
+                return None;
+            }
+            let mut width = 0;
+            let mut height = 0;
+            if !sys::SteamAPI_ISteamUtils_GetImageSize(utils, img, &mut width, &mut height) {
+                return None;
+            }
+            assert_eq!(width, 32);
+            assert_eq!(height, 32);
+            let mut dest = vec![0; 32 * 32 * 4];
+            if !sys::SteamAPI_ISteamUtils_GetImageRGBA(utils, img, dest.as_mut_ptr(), 32 * 32 * 4) {
+                return None;
+            }
+            Some(dest)
+        }
+    }
+
+    /// Returns a small (64x64) avatar for the current user in RGBA format
+    pub fn medium_avatar(&self) -> Option<Vec<u8>> {
+        unsafe {
+            let user: *mut sys::ISteamUser = sys::SteamAPI_SteamUser_v023();
+            let steam_id = sys::SteamAPI_ISteamUser_GetSteamID(user);
+            let utils = sys::SteamAPI_SteamUtils_v010();
+            let img = sys::SteamAPI_ISteamFriends_GetMediumFriendAvatar(self.friends, steam_id);
+            if img == 0 {
+                return None;
+            }
+            let mut width = 0;
+            let mut height = 0;
+            if !sys::SteamAPI_ISteamUtils_GetImageSize(utils, img, &mut width, &mut height) {
+                return None;
+            }
+            assert_eq!(width, 64);
+            assert_eq!(height, 64);
+            let mut dest = vec![0; 64 * 64 * 4];
+            if !sys::SteamAPI_ISteamUtils_GetImageRGBA(utils, img, dest.as_mut_ptr(), 64 * 64 * 4) {
+                return None;
+            }
+            Some(dest)
+        }
+    }
+
+    /// Returns a small (184x184) avatar for the current user in RGBA format
+    pub fn large_avatar(&self) -> Option<Vec<u8>> {
+        unsafe {
+            let user: *mut sys::ISteamUser = sys::SteamAPI_SteamUser_v023();
+            let steam_id = sys::SteamAPI_ISteamUser_GetSteamID(user);
+            let utils = sys::SteamAPI_SteamUtils_v010();
+            let img = sys::SteamAPI_ISteamFriends_GetLargeFriendAvatar(self.friends, steam_id);
+            if img == 0 {
+                return None;
+            }
+            let mut width = 0;
+            let mut height = 0;
+            if !sys::SteamAPI_ISteamUtils_GetImageSize(utils, img, &mut width, &mut height) {
+                return None;
+            }
+            assert_eq!(width, 184);
+            assert_eq!(height, 184);
+            let mut dest = vec![0; 184 * 184 * 4];
+            if !sys::SteamAPI_ISteamUtils_GetImageRGBA(utils, img, dest.as_mut_ptr(), 184 * 184 * 4)
+            {
+                return None;
+            }
+            Some(dest)
+        }
+    }
+
     pub fn get_friends(&self, flags: FriendFlags) -> Vec<Friend<Manager>> {
         unsafe {
             let count = sys::SteamAPI_ISteamFriends_GetFriendCount(self.friends, flags.bits() as _);


### PR DESCRIPTION
Added a new function wrapper `get_friends_from_source`...
Unfortunately the name is very misleading. This will not only get "friends" from the source (gameserver, lobby, chat room), but it will return all users. However the steamworks api has it named the same way so I thought I would keep it.

Also it requires a client to be connected to the source in order to work. Once connected you will be able to get all users on that particular gameserver etc.