### PR TITLE
Incorrect assert in networking_types

### DIFF
--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1500,7 +1500,7 @@ impl NetworkingConfigEntry {
     }
 
     pub fn new_float(value_type: NetworkingConfigValue, value: f32) -> Self {
-        debug_assert_eq!(value_type.data_type(), NetworkingConfigDataType::Int64);
+        debug_assert_eq!(value_type.data_type(), NetworkingConfigDataType::Float);
 
         let mut config = Self::new_uninitialized_config_value();
         unsafe {


### PR DESCRIPTION
It seems impossible to provide a float NetworkingConfigValue because of a bug in the assert function