### PR TITLE
fix: remove unnecesary panic when checking achievement icon size

### DIFF
--- a/src/user_stats/stats.rs
+++ b/src/user_stats/stats.rs
@@ -207,8 +207,9 @@ impl<M> AchievementHelper<'_, M> {
             if !sys::SteamAPI_ISteamUtils_GetImageSize(utils, img, &mut width, &mut height) {
                 return None;
             }
-            assert_eq!(width, 64);
-            assert_eq!(height, 64);
+            if width != 64 || height != 64 {
+                return None;
+            }
             let mut dest = vec![0; 64 * 64 * 4];
             if !sys::SteamAPI_ISteamUtils_GetImageRGBA(utils, img, dest.as_mut_ptr(), 64 * 64 * 4) {
                 return None;


### PR DESCRIPTION
This PR tries to avoid the library panicking if a achievement doesn't have the proper size by returning None instead

This helps with #172 although I don't think it fully fixes it as a permanent fix should include returning any achievement (possibly in a V2 function returning a more complex struct)