### PR TITLE
fix(friends): add null check to nick_name

### DIFF
--- a/src/friends.rs
+++ b/src/friends.rs
@@ -344,6 +344,10 @@ impl<Manager> Friend<Manager> {
     pub fn nick_name(&self) -> Option<String> {
         unsafe {
             let name = sys::SteamAPI_ISteamFriends_GetPlayerNickname(self.friends, self.id.0);
+            if name.is_null() {
+                return None;
+            }
+
             let name = CStr::from_ptr(name);
             if name.is_empty() {
                 None


### PR DESCRIPTION
Had some issues using this, would cause status access violations. Returns a null pointer if not found and needs to be checked.
 
 [Steamworks API - GetPlayerNickname](https://partner.steamgames.com/doc/api/ISteamFriends#GetPlayerNickname)