### PR TITLE
Remove SingleClient

### DIFF
--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -891,7 +891,7 @@ unsafe impl Callback for LobbyDataUpdate {
 #[test]
 #[serial]
 fn test_lobby() {
-    let (client, single) = Client::init().unwrap();
+    let client = Client::init().unwrap();
     let mm = client.matchmaking();
 
     mm.request_lobby_list(|v| {
@@ -911,7 +911,7 @@ fn test_lobby() {
     });
 
     for _ in 0..100 {
-        single.run_callbacks();
+        client.run_callbacks();
         ::std::thread::sleep(::std::time::Duration::from_millis(100));
     }
 }

--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -160,7 +160,7 @@ impl<Manager: 'static> NetworkingMessages<Manager> {
     ///
     /// Use the [`SessionRequest`](../networking_messages/struct.SessionRequest.html) to accept or reject the connection.
     ///
-    /// Requires regularly calling [`SingleClient.run_callbacks()`](../struct.SingleClient.html#method.run_callbacks).
+    /// Requires regularly calling [`Client.run_callbacks()`](../struct.Client.html#method.run_callbacks).
     /// Calling this function more than once will replace the previous callback.
     ///
     /// # Example
@@ -203,7 +203,7 @@ impl<Manager: 'static> NetworkingMessages<Manager> {
 
     /// Register a callback that will be called whenever a connection fails to be established.
     ///
-    /// Requires regularly calling [`SingleClient.run_callbacks()`](../struct.SingleClient.html#method.run_callbacks).
+    /// Requires regularly calling [`Client.run_callbacks()`](../struct.Client.html#method.run_callbacks).
     /// Calling this function more than once will replace the previous callback.
     pub fn session_failed_callback(
         &self,

--- a/src/networking_sockets.rs
+++ b/src/networking_sockets.rs
@@ -1031,7 +1031,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_create_listen_socket_ip() {
-        let (client, _single) = Client::init().unwrap();
+        let client = Client::init().unwrap();
         let sockets = client.networking_sockets();
         let socket_result = sockets.create_listen_socket_ip(
             SocketAddr::new(Ipv4Addr::new(0, 0, 0, 0).into(), 12345),
@@ -1042,7 +1042,7 @@ mod tests {
 
     #[test]
     fn test_socket_connection() {
-        let (client, single) = Client::init().unwrap();
+        let client = Client::init().unwrap();
         let sockets = client.networking_sockets();
 
         sockets.init_authentication().unwrap();
@@ -1065,7 +1065,7 @@ mod tests {
 
         println!("Run callbacks");
         for _ in 0..5 {
-            single.run_callbacks();
+            client.run_callbacks();
             std::thread::sleep(::std::time::Duration::from_millis(50));
         }
 
@@ -1080,7 +1080,7 @@ mod tests {
 
         println!("Run callbacks");
         for _ in 0..5 {
-            single.run_callbacks();
+            client.run_callbacks();
             std::thread::sleep(::std::time::Duration::from_millis(50));
         }
 

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -2232,7 +2232,7 @@ mod tests {
 
     #[test]
     fn test_allocate_and_free_message() {
-        let (client, _single) = Client::init().unwrap();
+        let client = Client::init().unwrap();
         let utils = client.networking_utils();
 
         // With C buffer

--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -200,8 +200,9 @@ mod tests {
 
     #[test]
     fn test_get_networking_status() {
-        let (client, single) = Client::init().unwrap();
-        std::thread::spawn(move || single.run_callbacks());
+        let client = Client::init().unwrap();
+        let callback_client = client.clone();
+        std::thread::spawn(move || callback_client.run_callbacks());
 
         let utils = client.networking_utils();
         let status = utils.detailed_relay_network_status();

--- a/src/remote_storage.rs
+++ b/src/remote_storage.rs
@@ -303,7 +303,7 @@ pub struct SteamFileInfo {
 #[serial]
 fn test_cloud() {
     use std::io::{Read, Write};
-    let (client, _single) = Client::init().unwrap();
+    let client = Client::init().unwrap();
 
     let rs = client.remote_storage();
     println!("Listing files:");

--- a/src/server.rs
+++ b/src/server.rs
@@ -100,7 +100,7 @@ impl Server {
         query_port: u16,
         server_mode: ServerMode,
         version: &str,
-    ) -> SIResult<(Server, SingleClient<ServerManager>)> {
+    ) -> SIResult<(Server, Client<ServerManager>)> {
         unsafe {
             let version = CString::new(version).unwrap();
 
@@ -148,10 +148,7 @@ impl Server {
                     inner: server.clone(),
                     server: server_raw,
                 },
-                SingleClient {
-                    inner: server,
-                    _not_sync: PhantomData,
-                },
+                Client { inner: server },
             ))
         }
     }

--- a/src/user.rs
+++ b/src/user.rs
@@ -175,7 +175,7 @@ pub enum AuthSessionError {
 #[test]
 #[serial]
 fn test_auth_dll() {
-    let (client, single) = Client::init().unwrap();
+    let client = Client::init().unwrap();
     let user = client.user();
 
     let _cb = client.register_callback(|v: AuthSessionTicketResponse| {
@@ -194,7 +194,7 @@ fn test_auth_dll() {
     println!("{:?}", user.begin_authentication_session(id, &ticket));
 
     for _ in 0..20 {
-        single.run_callbacks();
+        client.run_callbacks();
         ::std::thread::sleep(::std::time::Duration::from_millis(50));
     }
 
@@ -203,7 +203,7 @@ fn test_auth_dll() {
     user.cancel_authentication_ticket(auth);
 
     for _ in 0..20 {
-        single.run_callbacks();
+        client.run_callbacks();
         ::std::thread::sleep(::std::time::Duration::from_millis(50));
     }
 
@@ -246,7 +246,7 @@ unsafe impl Callback for AuthSessionTicketResponse {
 #[test]
 #[serial]
 fn test_auth_webapi() {
-    let (client, single) = Client::init().unwrap();
+    let client = Client::init().unwrap();
     let user = client.user();
 
     let _cb = client.register_callback(|v: TicketForWebApiResponse| {
@@ -258,7 +258,7 @@ fn test_auth_webapi() {
     println!("{:?}", auth);
 
     for _ in 0..20 {
-        single.run_callbacks();
+        client.run_callbacks();
         ::std::thread::sleep(::std::time::Duration::from_millis(100));
     }
 

--- a/src/user_stats.rs
+++ b/src/user_stats.rs
@@ -572,7 +572,7 @@ impl Leaderboard {
 #[ignore]
 #[serial]
 fn test() {
-    let (client, single) = Client::init().unwrap();
+    let client = Client::init().unwrap();
 
     let stats = client.user_stats();
 
@@ -612,7 +612,7 @@ fn test() {
     );
 
     for _ in 0..50 {
-        single.run_callbacks();
+        client.run_callbacks();
         ::std::thread::sleep(::std::time::Duration::from_millis(100));
     }
 }


### PR DESCRIPTION
Closes: https://github.com/Noxime/steamworks-rs/issues/159

The tests do not run for me, neither on main nor on this branch. I get a bunch of timeouts like these:

```
test matchmaking::test_lobby has been running for over 60 seconds
test networking_sockets::tests::test_create_listen_socket_ip has been running for over 60 seconds
test networking_sockets::tests::test_socket_connection has been running for over 60 seconds
test networking_types::tests::test_allocate_and_free_message has been running for over 60 seconds
test networking_utils::tests::test_get_networking_status has been running for over 60 seconds
test remote_storage::test_cloud has been running for over 60 seconds
```

I am also confused about this text in the Steam docs, referenced by @james7132 in the above issue:

> SteamAPI_RunCallbacks is safe to call from multiple threads simultaneously, but if you choose to do this, callback code could be executed on any thread. One alternative is to call SteamAPI_RunCallbacks from the main thread only, and call [SteamAPI_ReleaseCurrentThreadMemory](https://partner.steamgames.com/doc/api/steam_api#SteamAPI_ReleaseCurrentThreadMemory) regularly on other threads.

If I only run `run_callbacks` from the main thread, why would I need to release memory on other threads? And if this is a problem, isn't it also a problem with the current bindings since there is no helper for cleaning up memory on other threads?