### PR TITLE
Add binding for show_binding_panel

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -187,6 +187,17 @@ impl<Manager> Input<Manager> {
         unsafe { sys::SteamAPI_ISteamInput_GetMotionData(self.input, input_handle) }
     }
 
+    /// Invokes the Steam overlay and brings up the binding screen.
+    /// Returns true for success, false if overlay is disabled/unavailable.
+    /// If the player is using Big Picture Mode the configuration will open in
+    /// the overlay. In desktop mode a popup window version of Big Picture will
+    /// be created and open the configuration.
+    pub fn show_binding_panel(&self, input_handle: sys::InputHandle_t) -> bool {
+        unsafe {
+            sys::SteamAPI_ISteamInput_ShowBindingPanel(self.input, input_handle)
+        }
+    }
+
     /// Shutdown must be called when ending use of this interface.
     pub fn shutdown(&self) {
         unsafe {

--- a/src/input.rs
+++ b/src/input.rs
@@ -193,9 +193,7 @@ impl<Manager> Input<Manager> {
     /// the overlay. In desktop mode a popup window version of Big Picture will
     /// be created and open the configuration.
     pub fn show_binding_panel(&self, input_handle: sys::InputHandle_t) -> bool {
-        unsafe {
-            sys::SteamAPI_ISteamInput_ShowBindingPanel(self.input, input_handle)
-        }
+        unsafe { sys::SteamAPI_ISteamInput_ShowBindingPanel(self.input, input_handle) }
     }
 
     /// Shutdown must be called when ending use of this interface.


### PR DESCRIPTION
Adds show_binding_panel from the Steam Input API.

Tested on macOS with steamworks sdk version 1.59.