### PR TITLE
Adds LobbyChatMsg callback and get_lobby_chat_entry function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ image = ["dep:image"]
 [workspace]
 members = [
     "./steamworks-sys",
-    "examples/chat-example",
+    "examples/chat-example", "examples/lobby",
     "examples/workshop"
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ image = ["dep:image"]
 [workspace]
 members = [
     "./steamworks-sys",
-    "examples/chat-example", "examples/lobby",
-    "examples/workshop"
+    "examples/chat-example",
+    "examples/workshop",
+	"examples/lobby",
 ]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
     "./steamworks-sys",
     "examples/chat-example",
     "examples/workshop",
-	"examples/lobby",
+    "examples/lobby",
 ]
 
 [dependencies]

--- a/examples/lobby/Cargo.toml
+++ b/examples/lobby/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "lobby"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+steamworks = { path = "../../" }

--- a/examples/lobby/src/main.rs
+++ b/examples/lobby/src/main.rs
@@ -1,0 +1,38 @@
+use std::sync::mpsc;
+
+use steamworks::*;
+
+fn main() {
+    let (client, single) = Client::init().unwrap();
+
+    let matchmaking = client.matchmaking();
+
+    let (sender_create_lobby, receiver_create_lobby) = mpsc::channel();
+
+    // let mut lobby_id_state: Option<LobbyId> = None;
+
+    matchmaking.create_lobby(LobbyType::Private, 4, move |result| match result {
+        Ok(lobby_id) => {
+            sender_create_lobby.send(lobby_id).unwrap();
+            println!("Created lobby: [{}]", lobby_id.raw())
+        }
+        Err(err) => panic!("Error: {}", err),
+    });
+
+    client.register_callback(move |message: LobbyChatMsg| {
+        println!("Lobby chat message received: {:?}", message);
+    });
+
+    loop {
+        single.run_callbacks();
+
+        if let Ok(lobby_id) = receiver_create_lobby.try_recv() {
+            // lobby_id_state = Some(lobby_id);
+
+            println!("Sending message to lobby chat...");
+            matchmaking
+                .send_lobby_chat_message(lobby_id, &[0, 1, 2, 3, 4])
+                .expect("Failed to send chat message to lobby");
+        }
+    }
+}

--- a/examples/lobby/src/main.rs
+++ b/examples/lobby/src/main.rs
@@ -29,16 +29,16 @@ fn main() {
         if let Ok(lobby_id) = receiver_create_lobby.try_recv() {
             println!("Sending message to lobby chat...");
             matchmaking
-                .send_lobby_chat_message(lobby_id, &[0, 1, 2, 3, 4, 100])
+                .send_lobby_chat_message(lobby_id, &[0, 1, 2, 3, 4, 5])
                 .expect("Failed to send chat message to lobby");
         }
 
         if let Ok(message) = receiver_lobby_chat_msg.try_recv() {
             let mut buffer = vec![0; 256];
-            matchmaking.get_lobby_chat_entry(
+            let buffer = matchmaking.get_lobby_chat_entry(
                 message.lobby,
                 message.chat_id,
-                &mut buffer.as_mut_slice(),
+                buffer.as_mut_slice(),
             );
             println!("Message buffer: [{:?}]", buffer);
         }

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -888,6 +888,31 @@ unsafe impl Callback for LobbyDataUpdate {
     }
 }
 
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct LobbyChatMsg {
+    pub lobby: LobbyId,
+    pub user: SteamId,
+    pub chat_entry_type: u8,
+    pub chat_id: u32,
+}
+
+unsafe impl Callback for LobbyChatMsg {
+    const ID: i32 = 507;
+    const SIZE: i32 = ::std::mem::size_of::<sys::LobbyChatMsg_t>() as i32;
+
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
+        let val = &mut *(raw as *mut sys::LobbyChatMsg_t);
+
+        LobbyChatMsg {
+            lobby: LobbyId(val.m_ulSteamIDLobby),
+            user: SteamId(val.m_ulSteamIDUser),
+            chat_entry_type: val.m_eChatEntryType,
+            chat_id: val.m_iChatID,
+        }
+    }
+}
+
 #[test]
 #[serial]
 fn test_lobby() {

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -989,8 +989,6 @@ unsafe impl Callback for LobbyChatMsg {
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::LobbyChatMsg_t);
 
-        println!("Raw: {:?}", val);
-
         LobbyChatMsg {
             lobby: LobbyId(val.m_ulSteamIDLobby),
             user: SteamId(val.m_ulSteamIDUser),

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -312,6 +312,16 @@ impl<Manager> Matchmaking<Manager> {
         }
     }
 
+    /// Gets the data from a lobby chat message after receiving a `LobbyChatMsg_t` callback.
+    ///
+    /// # Parameters
+    /// - `lobby`: The Steam ID of the lobby to get the chat message from.
+    /// - `chat_id`: The index of the chat entry in the lobby.
+    /// - `buffer`: Return the message data by copying it into this buffer. The buffer should be up
+    /// to 4 Kilobytes.
+    ///
+    /// # Returns
+    /// Returns `usize` The number of bytes copied into buffer
     pub fn get_lobby_chat_entry(&self, lobby: LobbyId, chat_id: i32, buffer: &mut [u8]) -> usize {
         let steam_user = sys::CSteamID_SteamID_t { m_unAll64Bits: 0 };
         let mut steam_user = sys::CSteamID {

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, mem, slice::from_raw_parts};
+use std::fmt::Display;
 
 use super::*;
 #[cfg(test)]

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -327,8 +327,6 @@ impl<Manager> Matchmaking<Manager> {
         let mut steam_user = sys::CSteamID {
             m_steamid: steam_user,
         };
-        // let message: *mut c_void = 0 as *mut c_void;
-        // let buffer: &mut [u8] = vec![0; message_size].as_mut_slice();
         let mut chat_type = steamworks_sys::EChatEntryType::k_EChatEntryTypeInvalid;
         unsafe {
             let elements = sys::SteamAPI_ISteamMatchmaking_GetLobbyChatEntry(

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -317,11 +317,11 @@ impl<Manager> Matchmaking<Manager> {
     /// # Parameters
     /// - `lobby`: The Steam ID of the lobby to get the chat message from.
     /// - `chat_id`: The index of the chat entry in the lobby.
-    /// - `buffer`: Return the message data by copying it into this buffer. The buffer should be up
-    /// to 4 Kilobytes.
+    /// - `buffer`: Buffer to save retrieved message data to. The buffer should be no
+    /// more than 4 Kilobytes.
     ///
     /// # Returns
-    /// Returns `usize` The number of bytes copied into buffer
+    /// Returns `&[u8]` A resliced byte array of the message buffer
     pub fn get_lobby_chat_entry<'a>(
         &self,
         lobby: LobbyId,


### PR DESCRIPTION
#### Adds
* `LobbyChatMsg` callback, used to receive messages from matchmaking lobbies send by `matchmaking.send_lobby_chat_msg`.
* `get_lobby_chat_entry` function, used to receiver message buffers from `LobbyChatMsg` callback.
* Simple example `lobby` to demonstrate this functionality.

#### Relevant steamworks docs:
* `LobbyChatMsg_t`: https://partner.steamgames.com/doc/api/ISteamMatchmaking#LobbyChatMsg_t
* `GetLobbyChatEntry`: https://partner.steamgames.com/doc/api/ISteamMatchmaking#GetLobbyChatEntry 

Please let me know what if there is anything I'm missing, this is my first time contributing to this repo :)