### PR TITLE
Made all callbacks public

### DIFF
--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -242,7 +242,7 @@ impl<Manager> SessionRequestBuilder<Manager> {
     }
 }
 
-struct NetworkingMessagesSessionRequest {
+pub struct NetworkingMessagesSessionRequest {
     remote: NetworkingIdentity,
 }
 

--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -177,7 +177,7 @@ impl From<sys::SteamRelayNetworkStatus_t> for RelayNetworkStatus {
 }
 
 /// The relay network status callback.
-struct RelayNetworkStatusCallback {
+pub struct RelayNetworkStatusCallback {
     status: RelayNetworkStatus,
 }
 


### PR DESCRIPTION
I need to access these callbacks for a bevy integration of steamworks-rs so I made them public.