### PR TITLE
Add GameRichPresenceJoinRequested

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -14,6 +14,7 @@ pub enum CallbackResult {
     GameLobbyJoinRequested(GameLobbyJoinRequested),
     GameOverlayActivated(GameOverlayActivated),
     GamepadTextInputDismissed(GamepadTextInputDismissed),
+    GameRichPresenceJoinRequested(GameRichPresenceJoinRequested),
     LobbyChatUpdate(LobbyChatUpdate),
     LobbyDataUpdate(LobbyDataUpdate),
     MicroTxnAuthorizationResponse(MicroTxnAuthorizationResponse),
@@ -53,6 +54,9 @@ impl CallbackResult {
             }
             GamepadTextInputDismissed::ID => {
                 Self::GamepadTextInputDismissed(GamepadTextInputDismissed::from_raw(data))
+            }
+            GameRichPresenceJoinRequested::ID => {
+                Self::GameRichPresenceJoinRequested(GameRichPresenceJoinRequested::from_raw(data))
             }
             LobbyChatUpdate::ID => Self::LobbyChatUpdate(LobbyChatUpdate::from_raw(data)),
             LobbyDataUpdate::ID => Self::LobbyDataUpdate(LobbyDataUpdate::from_raw(data)),

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -316,6 +316,31 @@ unsafe impl Callback for GameLobbyJoinRequested {
     }
 }
 
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct GameRichPresenceJoinRequested {
+    /// If you are joining a friend/being invited from a friend, this `SteamId` will be of said friend.
+    /// If it's not coming from a friend, this `SteamId` will be invalid, which you can check with the `.is_invalid()`
+    /// method.
+    pub friend_steam_id: SteamId,
+    /// the connect string, holding custom data to join a game or friend
+    pub connect: String,
+}
+
+unsafe impl Callback for GameRichPresenceJoinRequested {
+    const ID: i32 = sys::GameRichPresenceJoinRequested_t_k_iCallback as i32;
+
+    unsafe fn from_raw(raw: *mut c_void) -> Self {
+        let val = &mut *(raw as *mut sys::GameRichPresenceJoinRequested_t);
+        // transmute from &[i8] to &[u8] because c_char in C is signed.
+        let connect_bytes: &[u8] = std::mem::transmute(&val.m_rgchConnect as &[i8]);
+        GameRichPresenceJoinRequested {
+            friend_steam_id: SteamId(val.m_steamIDFriend.m_steamid.m_unAll64Bits),
+            connect: String::from_utf8_lossy(&connect_bytes).trim().to_string(),
+        }
+    }
+}
+
 pub struct Friend {
     id: SteamId,
     friends: *mut sys::ISteamFriends,

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -336,7 +336,7 @@ unsafe impl Callback for GameRichPresenceJoinRequested {
         let connect_bytes: &[u8] = std::mem::transmute(&val.m_rgchConnect as &[i8]);
         GameRichPresenceJoinRequested {
             friend_steam_id: SteamId(val.m_steamIDFriend.m_steamid.m_unAll64Bits),
-            connect: String::from_utf8_lossy(&connect_bytes).trim().to_string(),
+            connect: String::from_utf8_lossy(&connect_bytes).trim_end_matches('\0').to_string(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,6 +553,16 @@ impl SteamId {
         self.0
     }
 
+    /// Returns whether or not this Steam ID is invalid, which is when `account_type` is `k_EAccountTypeInvalid`.
+    pub fn is_invalid(&self) -> bool {
+        unsafe {
+            let bits = sys::CSteamID_SteamID_t {
+                m_unAll64Bits: self.0,
+            };
+            bits.m_comp.m_EAccountType() == sys::EAccountType::k_EAccountTypeInvalid as std::os::raw::c_uint
+        }
+    }
+
     /// Returns the account id for this steam id
     pub fn account_id(&self) -> AccountId {
         unsafe {


### PR DESCRIPTION
Adds the callback `GameRichPresenceJoinRequested_t`, which is triggered when you click "Join Game" on a friend when he is in the same game as you. Basically essential for many multiplayer games.

Tested the base feature with 2 separate accounts that were friends with each other, but I couldn't test the part where you joined a non-friend's game (doc says it's possible through community, but I don't know how).