### PR TITLE
chore: Update and cleanup dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         toolchain: [stable, nightly, "1.73.0"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         id: toolchain
@@ -28,7 +28,7 @@ jobs:
         if: runner.os == 'linux'
 
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,16 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all
+          args: --lib
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0"
+
+      - uses: actions-rs/cargo@v1
+        if: runner.toolchain in ['stable', 'nightly']
+        with:
+          command: build
+          args: --examples
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           RUSTFLAGS: "-C debuginfo=0"
 
       - uses: actions-rs/cargo@v1
-        if: runner.toolchain in ['stable', 'nightly']
+        if: ${{ matrix.toolchain }}== ['stable', 'nightly']
         with:
           command: build
           args: --examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ members = [
 
 [dependencies]
 steamworks-sys = { path = "./steamworks-sys", version = "0.11.0" }
-thiserror = "1.0"
-bitflags = "1.2"
+thiserror = "2.0"
+bitflags = "2.9"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"], optional = true }
 paste = "1.0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ members = [
 steamworks-sys = { path = "./steamworks-sys", version = "0.11.0" }
 thiserror = "2.0"
 bitflags = "2.9"
-lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"], optional = true }
 paste = "1.0.11"
 image = { version = "0.25.1", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ paste = "1.0.11"
 image = { version = "0.25.1", optional = true, default-features = false }
 
 [dev-dependencies]
-serial_test = "1"
+serial_test = "3.2"

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -6,6 +6,7 @@ const CALLBACK_BASE_ID: i32 = 300;
 bitflags! {
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[repr(C)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct FriendFlags: u16 {
         const NONE                  = 0x0000;
         const BLOCKED               = 0x0001;
@@ -28,6 +29,7 @@ bitflags! {
 bitflags! {
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[repr(C)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct PersonaChange: i32 {
         const NAME                = 0x0001;
         const STATUS              = 0x0002;
@@ -49,6 +51,7 @@ bitflags! {
 bitflags! {
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[repr(C)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     /// see [Steam API](https://partner.steamgames.com/doc/api/ISteamFriends#EUserRestriction)
     pub struct UserRestriction: u32 {
         /// No known chat/content restriction.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 extern crate thiserror;
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate lazy_static;
 
 use screenshots::Screenshots;
 #[cfg(feature = "raw-bindings")]

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -27,6 +27,7 @@ impl From<MessageNumber> for u64 {
 bitflags! {
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[repr(C)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct SendFlags: i32 {
         const UNRELIABLE = sys::k_nSteamNetworkingSend_Unreliable;
         const NO_NAGLE = sys::k_nSteamNetworkingSend_NoNagle;

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -412,6 +412,7 @@ impl Into<sys::EItemStatistic> for UGCStatisticType {
 }
 
 bitflags! {
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct ItemState: u32 {
         const NONE = 0;
         const SUBSCRIBED = 1;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -110,14 +110,12 @@ impl From<FloatingGamepadTextInputMode> for sys::EFloatingGamepadTextInputMode {
     }
 }
 
-lazy_static! {
-    /// Global rust warning callback
-    static ref WARNING_CALLBACK: RwLock<Option<Box<dyn Fn(i32, &CStr) + Send + Sync>>> = RwLock::new(None);
-}
+/// Global rust warning callback
+static WARNING_CALLBACK: RwLock<Option<Box<dyn Fn(i32, &CStr) + Send + Sync>>> = RwLock::new(None);
 
 /// C function to pass as the real callback, which forwards to the `WARNING_CALLBACK` if any
 unsafe extern "C" fn c_warning_callback(level: i32, msg: *const c_char) {
-    let lock = WARNING_CALLBACK.read().expect("warning func lock poisoned");
+    let lock = WARNING_CALLBACK. read().expect("warning func lock poisoned");
     let cb = match lock.as_ref() {
         Some(cb) => cb,
         None => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -115,7 +115,7 @@ static WARNING_CALLBACK: RwLock<Option<Box<dyn Fn(i32, &CStr) + Send + Sync>>> =
 
 /// C function to pass as the real callback, which forwards to the `WARNING_CALLBACK` if any
 unsafe extern "C" fn c_warning_callback(level: i32, msg: *const c_char) {
-    let lock = WARNING_CALLBACK. read().expect("warning func lock poisoned");
+    let lock = WARNING_CALLBACK.read().expect("warning func lock poisoned");
     let cb = match lock.as_ref() {
         Some(cb) => cb,
         None => {


### PR DESCRIPTION
This PR updates several outdated dependencies (bitflags, serde_test, thiserror) and removes a now unnecessary dependency on lazy_static.

lazy_static is no longer needed as `RwLock::new` is now const as of Rust 1.63.

Also updated and fixed up the CI checks.