### PR TITLE
Properly implement Drop for CallbackHandle

### DIFF
--- a/src/friends.rs
+++ b/src/friends.rs
@@ -419,8 +419,6 @@ impl<Manager> Friend<Manager> {
             if !sys::SteamAPI_ISteamUtils_GetImageSize(utils, img, &mut width, &mut height) {
                 return None;
             }
-            assert_eq!(width, 32);
-            assert_eq!(height, 32);
             let mut dest = vec![0; 32 * 32 * 4];
             if !sys::SteamAPI_ISteamUtils_GetImageRGBA(utils, img, dest.as_mut_ptr(), 32 * 32 * 4) {
                 return None;
@@ -442,8 +440,6 @@ impl<Manager> Friend<Manager> {
             if !sys::SteamAPI_ISteamUtils_GetImageSize(utils, img, &mut width, &mut height) {
                 return None;
             }
-            assert_eq!(width, 64);
-            assert_eq!(height, 64);
             let mut dest = vec![0; 64 * 64 * 4];
             if !sys::SteamAPI_ISteamUtils_GetImageRGBA(utils, img, dest.as_mut_ptr(), 64 * 64 * 4) {
                 return None;
@@ -465,8 +461,6 @@ impl<Manager> Friend<Manager> {
             if !sys::SteamAPI_ISteamUtils_GetImageSize(utils, img, &mut width, &mut height) {
                 return None;
             }
-            assert_eq!(width, 184);
-            assert_eq!(height, 184);
             let mut dest = vec![0; 184 * 184 * 4];
             if !sys::SteamAPI_ISteamUtils_GetImageRGBA(utils, img, dest.as_mut_ptr(), 184 * 184 * 4)
             {

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -270,7 +270,6 @@ pub struct PersonaStateChange {
 
 unsafe impl Callback for PersonaStateChange {
     const ID: i32 = CALLBACK_BASE_ID + 4;
-    const SIZE: i32 = ::std::mem::size_of::<sys::PersonaStateChange_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::PersonaStateChange_t);
@@ -289,7 +288,6 @@ pub struct GameOverlayActivated {
 
 unsafe impl Callback for GameOverlayActivated {
     const ID: i32 = CALLBACK_BASE_ID + 31;
-    const SIZE: i32 = std::mem::size_of::<sys::GameOverlayActivated_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::GameOverlayActivated_t);
@@ -308,7 +306,6 @@ pub struct GameLobbyJoinRequested {
 
 unsafe impl Callback for GameLobbyJoinRequested {
     const ID: i32 = CALLBACK_BASE_ID + 33;
-    const SIZE: i32 = ::std::mem::size_of::<sys::GameLobbyJoinRequested_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::GameLobbyJoinRequested_t);

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -965,7 +965,6 @@ pub struct LobbyChatUpdate {
 
 unsafe impl Callback for LobbyChatUpdate {
     const ID: i32 = 506;
-    const SIZE: i32 = ::std::mem::size_of::<sys::LobbyChatUpdate_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::LobbyChatUpdate_t);
@@ -1008,7 +1007,6 @@ pub struct LobbyDataUpdate {
 
 unsafe impl Callback for LobbyDataUpdate {
     const ID: i32 = 505;
-    const SIZE: i32 = ::std::mem::size_of::<sys::LobbyDataUpdate_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::LobbyDataUpdate_t);
@@ -1032,7 +1030,6 @@ pub struct LobbyChatMsg {
 
 unsafe impl Callback for LobbyChatMsg {
     const ID: i32 = 507;
-    const SIZE: i32 = ::std::mem::size_of::<sys::LobbyChatMsg_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::LobbyChatMsg_t);

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -145,7 +145,6 @@ pub struct P2PSessionRequest {
 
 unsafe impl Callback for P2PSessionRequest {
     const ID: i32 = 1202;
-    const SIZE: i32 = ::std::mem::size_of::<sys::P2PSessionRequest_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::P2PSessionRequest_t);
@@ -164,7 +163,6 @@ pub struct P2PSessionConnectFail {
 
 unsafe impl Callback for P2PSessionConnectFail {
     const ID: i32 = 1203;
-    const SIZE: i32 = ::std::mem::size_of::<sys::P2PSessionConnectFail_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::P2PSessionConnectFail_t);

--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -249,7 +249,6 @@ pub struct NetworkingMessagesSessionRequest {
 
 unsafe impl Callback for NetworkingMessagesSessionRequest {
     const ID: i32 = sys::SteamNetworkingMessagesSessionRequest_t_k_iCallback as _;
-    const SIZE: i32 = std::mem::size_of::<sys::SteamNetworkingMessagesSessionRequest_t>() as _;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let remote = *(raw as *mut sys::SteamNetworkingMessagesSessionRequest_t);
@@ -264,7 +263,6 @@ struct NetworkingMessagesSessionFailed {
 
 unsafe impl Callback for NetworkingMessagesSessionFailed {
     const ID: i32 = sys::SteamNetworkingMessagesSessionFailed_t_k_iCallback as _;
-    const SIZE: i32 = std::mem::size_of::<sys::SteamNetworkingMessagesSessionFailed_t>() as _;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let remote = *(raw as *mut sys::SteamNetworkingMessagesSessionFailed_t);

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1415,7 +1415,6 @@ pub struct NetConnectionStatusChanged {
 
 unsafe impl Callback for NetConnectionStatusChanged {
     const ID: i32 = sys::SteamNetConnectionStatusChangedCallback_t_k_iCallback as _;
-    const SIZE: i32 = std::mem::size_of::<sys::SteamNetConnectionStatusChangedCallback_t>() as _;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::SteamNetConnectionStatusChangedCallback_t);

--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -183,7 +183,6 @@ pub struct RelayNetworkStatusCallback {
 
 unsafe impl Callback for RelayNetworkStatusCallback {
     const ID: i32 = sys::SteamRelayNetworkStatus_t_k_iCallback as _;
-    const SIZE: i32 = std::mem::size_of::<sys::SteamRelayNetworkStatus_t>() as _;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let status = *(raw as *mut sys::SteamRelayNetworkStatus_t);

--- a/src/remote_play.rs
+++ b/src/remote_play.rs
@@ -161,7 +161,6 @@ pub struct RemotePlayConnected {
 
 unsafe impl Callback for RemotePlayConnected {
     const ID: i32 = sys::SteamRemotePlaySessionConnected_t_k_iCallback as i32;
-    const SIZE: i32 = ::std::mem::size_of::<sys::SteamRemotePlaySessionConnected_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::SteamRemotePlaySessionConnected_t);
@@ -181,7 +180,6 @@ pub struct RemotePlayDisconnected {
 
 unsafe impl Callback for RemotePlayDisconnected {
     const ID: i32 = sys::SteamRemotePlaySessionDisconnected_t_k_iCallback as i32;
-    const SIZE: i32 = ::std::mem::size_of::<sys::SteamRemotePlaySessionDisconnected_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::SteamRemotePlaySessionDisconnected_t);

--- a/src/screenshots.rs
+++ b/src/screenshots.rs
@@ -108,7 +108,6 @@ pub struct ScreenshotRequested;
 
 unsafe impl Callback for ScreenshotRequested {
     const ID: i32 = sys::ScreenshotRequested_t__bindgen_ty_1::k_iCallback as _;
-    const SIZE: i32 = std::mem::size_of::<sys::ScreenshotRequested_t>() as _;
 
     unsafe fn from_raw(_: *mut c_void) -> Self {
         Self
@@ -134,7 +133,6 @@ pub struct ScreenshotReady {
 
 unsafe impl Callback for ScreenshotReady {
     const ID: i32 = sys::ScreenshotReady_t__bindgen_ty_1::k_iCallback as _;
-    const SIZE: i32 = std::mem::size_of::<sys::ScreenshotReady_t>() as _;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let status = *(raw as *mut sys::ScreenshotReady_t);

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -494,7 +494,6 @@ pub struct DownloadItemResult {
 
 unsafe impl Callback for DownloadItemResult {
     const ID: i32 = CALLBACK_BASE_ID + 6;
-    const SIZE: i32 = ::std::mem::size_of::<sys::DownloadItemResult_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::DownloadItemResult_t);

--- a/src/user.rs
+++ b/src/user.rs
@@ -228,7 +228,6 @@ pub struct AuthSessionTicketResponse {
 
 unsafe impl Callback for AuthSessionTicketResponse {
     const ID: i32 = 163;
-    const SIZE: i32 = ::std::mem::size_of::<sys::GetAuthSessionTicketResponse_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::GetAuthSessionTicketResponse_t);
@@ -278,7 +277,6 @@ pub struct TicketForWebApiResponse {
 
 unsafe impl Callback for TicketForWebApiResponse {
     const ID: i32 = 168;
-    const SIZE: i32 = ::std::mem::size_of::<sys::GetTicketForWebApiResponse_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         println!("From raw: {:?}", raw);
@@ -312,7 +310,6 @@ pub struct ValidateAuthTicketResponse {
 
 unsafe impl Callback for ValidateAuthTicketResponse {
     const ID: i32 = 143;
-    const SIZE: i32 = ::std::mem::size_of::<sys::ValidateAuthTicketResponse_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::ValidateAuthTicketResponse_t);
@@ -365,7 +362,6 @@ pub struct MicroTxnAuthorizationResponse {
 
 unsafe impl Callback for MicroTxnAuthorizationResponse {
     const ID: i32 = 152;
-    const SIZE: i32 = std::mem::size_of::<sys::MicroTxnAuthorizationResponse_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::MicroTxnAuthorizationResponse_t);
@@ -384,7 +380,6 @@ pub struct SteamServersConnected;
 
 unsafe impl Callback for SteamServersConnected {
     const ID: i32 = 101;
-    const SIZE: i32 = ::std::mem::size_of::<sys::SteamServersConnected_t>() as i32;
 
     unsafe fn from_raw(_: *mut c_void) -> Self {
         SteamServersConnected
@@ -401,7 +396,6 @@ pub struct SteamServersDisconnected {
 
 unsafe impl Callback for SteamServersDisconnected {
     const ID: i32 = 103;
-    const SIZE: i32 = ::std::mem::size_of::<sys::SteamServersDisconnected_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::SteamServersDisconnected_t);
@@ -423,7 +417,6 @@ pub struct SteamServerConnectFailure {
 
 unsafe impl Callback for SteamServerConnectFailure {
     const ID: i32 = 102;
-    const SIZE: i32 = ::std::mem::size_of::<sys::SteamServerConnectFailure_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::SteamServerConnectFailure_t);

--- a/src/user_stats/stat_callback.rs
+++ b/src/user_stats/stat_callback.rs
@@ -23,7 +23,6 @@ pub struct UserStatsReceived {
 
 unsafe impl Callback for UserStatsReceived {
     const ID: i32 = CALLBACK_BASE_ID + 1;
-    const SIZE: i32 = std::mem::size_of::<sys::UserStatsReceived_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::UserStatsReceived_t);
@@ -59,7 +58,6 @@ pub struct UserStatsStored {
 
 unsafe impl Callback for UserStatsStored {
     const ID: i32 = CALLBACK_BASE_ID + 2;
-    const SIZE: i32 = std::mem::size_of::<sys::UserStatsStored_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::UserStatsStored_t);
@@ -98,7 +96,6 @@ pub struct UserAchievementStored {
 
 unsafe impl Callback for UserAchievementStored {
     const ID: i32 = CALLBACK_BASE_ID + 3;
-    const SIZE: i32 = std::mem::size_of::<sys::UserAchievementStored_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::UserAchievementStored_t);
@@ -132,7 +129,6 @@ pub struct UserAchievementIconFetched {
 
 unsafe impl Callback for UserAchievementIconFetched {
     const ID: i32 = CALLBACK_BASE_ID + 9;
-    const SIZE: i32 = std::mem::size_of::<sys::UserAchievementStored_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::UserAchievementIconFetched_t);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,6 @@ pub struct GamepadTextInputDismissed {
 
 unsafe impl Callback for GamepadTextInputDismissed {
     const ID: i32 = 714;
-    const SIZE: i32 = ::std::mem::size_of::<sys::GamepadTextInputDismissed_t>() as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::GamepadTextInputDismissed_t);
@@ -34,7 +33,6 @@ pub struct FloatingGamepadTextInputDismissed;
 
 unsafe impl Callback for FloatingGamepadTextInputDismissed {
     const ID: i32 = 738;
-    const SIZE: i32 = ::std::mem::size_of::<sys::FloatingGamepadTextInputDismissed_t>() as i32;
 
     unsafe fn from_raw(_: *mut c_void) -> Self {
         FloatingGamepadTextInputDismissed


### PR DESCRIPTION
The documentation for `CallbackHandle` says it removes the callback on dropping the the handle. This is not true. CallbackHandle does not implement `Drop`, instead relying on `CallbackHandle::disconnect` instead, which also does not take ownership of the handle.

This PR implements Drop for CallbackHandle, and removes `CallbackHandle::disconnect`. This is a breaking change.

As this is a breaking change, might as well remove the unused `SIZE` associated constant on the `Callback` trait.