### PR TITLE
Client::process_callbacks as a way to work with non-Send/'static callback handlers

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,8 +1,99 @@
 use super::*;
+use crate::networking_types::*;
 
 use crate::sys;
 
 use std::sync::{Arc, Weak};
+
+/// A sum type over all possible callback results
+pub enum CallbackResult {
+    NetConnectionStatusChanged(NetConnectionStatusChanged),
+    AuthSessionTicketResponse(AuthSessionTicketResponse),
+    DownloadItemResult(DownloadItemResult),
+    FloatingGamepadTextInputDismissed(FloatingGamepadTextInputDismissed),
+    GameLobbyJoinRequested(GameLobbyJoinRequested),
+    GameOverlayActivated(GameOverlayActivated),
+    GamepadTextInputDismissed(GamepadTextInputDismissed),
+    LobbyChatUpdate(LobbyChatUpdate),
+    LobbyDataUpdate(LobbyDataUpdate),
+    MicroTxnAuthorizationResponse(MicroTxnAuthorizationResponse),
+    P2PSessionConnectFail(P2PSessionConnectFail),
+    P2PSessionRequest(P2PSessionRequest),
+    PersonaStateChange(PersonaStateChange),
+    RemotePlayConnected(RemotePlayConnected),
+    RemotePlayDisconnected(RemotePlayDisconnected),
+    SteamServerConnectFailure(SteamServerConnectFailure),
+    SteamServersConnected(SteamServersConnected),
+    SteamServersDisconnected(SteamServersDisconnected),
+    TicketForWebApiResponse(TicketForWebApiResponse),
+    UserAchievementStored(UserAchievementStored),
+    UserStatsReceived(UserStatsReceived),
+    UserStatsStored(UserStatsStored),
+    ValidateAuthTicketResponse(ValidateAuthTicketResponse),
+}
+
+impl CallbackResult {
+    pub unsafe fn from_raw(discriminator: i32, data: *mut c_void) -> Option<Self> {
+        Some(match discriminator {
+            NetConnectionStatusChanged::ID => {
+                Self::NetConnectionStatusChanged(NetConnectionStatusChanged::from_raw(data))
+            }
+            AuthSessionTicketResponse::ID => {
+                Self::AuthSessionTicketResponse(AuthSessionTicketResponse::from_raw(data))
+            }
+            DownloadItemResult::ID => Self::DownloadItemResult(DownloadItemResult::from_raw(data)),
+            FloatingGamepadTextInputDismissed::ID => Self::FloatingGamepadTextInputDismissed(
+                FloatingGamepadTextInputDismissed::from_raw(data),
+            ),
+            GameLobbyJoinRequested::ID => {
+                Self::GameLobbyJoinRequested(GameLobbyJoinRequested::from_raw(data))
+            }
+            GameOverlayActivated::ID => {
+                Self::GameOverlayActivated(GameOverlayActivated::from_raw(data))
+            }
+            GamepadTextInputDismissed::ID => {
+                Self::GamepadTextInputDismissed(GamepadTextInputDismissed::from_raw(data))
+            }
+            LobbyChatUpdate::ID => Self::LobbyChatUpdate(LobbyChatUpdate::from_raw(data)),
+            LobbyDataUpdate::ID => Self::LobbyDataUpdate(LobbyDataUpdate::from_raw(data)),
+            MicroTxnAuthorizationResponse::ID => {
+                Self::MicroTxnAuthorizationResponse(MicroTxnAuthorizationResponse::from_raw(data))
+            }
+            P2PSessionConnectFail::ID => {
+                Self::P2PSessionConnectFail(P2PSessionConnectFail::from_raw(data))
+            }
+            P2PSessionRequest::ID => Self::P2PSessionRequest(P2PSessionRequest::from_raw(data)),
+            PersonaStateChange::ID => Self::PersonaStateChange(PersonaStateChange::from_raw(data)),
+            RemotePlayConnected::ID => {
+                Self::RemotePlayConnected(RemotePlayConnected::from_raw(data))
+            }
+            RemotePlayDisconnected::ID => {
+                Self::RemotePlayDisconnected(RemotePlayDisconnected::from_raw(data))
+            }
+            SteamServerConnectFailure::ID => {
+                Self::SteamServerConnectFailure(SteamServerConnectFailure::from_raw(data))
+            }
+            SteamServersConnected::ID => {
+                Self::SteamServersConnected(SteamServersConnected::from_raw(data))
+            }
+            SteamServersDisconnected::ID => {
+                Self::SteamServersDisconnected(SteamServersDisconnected::from_raw(data))
+            }
+            TicketForWebApiResponse::ID => {
+                Self::TicketForWebApiResponse(TicketForWebApiResponse::from_raw(data))
+            }
+            UserAchievementStored::ID => {
+                Self::UserAchievementStored(UserAchievementStored::from_raw(data))
+            }
+            UserStatsReceived::ID => Self::UserStatsReceived(UserStatsReceived::from_raw(data)),
+            UserStatsStored::ID => Self::UserStatsStored(UserStatsStored::from_raw(data)),
+            ValidateAuthTicketResponse::ID => {
+                Self::ValidateAuthTicketResponse(ValidateAuthTicketResponse::from_raw(data))
+            }
+            _ => return None,
+        })
+    }
+}
 
 pub unsafe trait Callback {
     const ID: i32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,39 @@ impl Client {
     /// This should be called frequently (e.g. once per a frame)
     /// in order to reduce the latency between recieving events.
     pub fn run_callbacks(&self) {
+        self.run_callbacks_raw(|callbacks, cb_discrim, data| {
+            if let Some(cb) = callbacks.callbacks.get_mut(&cb_discrim) {
+                cb(data);
+            }
+        });
+    }
+
+    /// Runs any currently pending callbacks.
+    ///
+    /// This is identical to `run_callbacks` in every way, except that
+    /// `callback_handler` is called for every callback invoked. 
+    ///
+    /// This option provides an alternative for handling callbacks that
+    /// can doesn't require the handler to be `Send`, and `'static`.
+    ///
+    /// This should be called frequently (e.g. once per a frame)
+    /// in order to reduce the latency between recieving events.
+    pub fn process_callbacks(&self, mut callback_handler: impl FnMut(CallbackResult)) {
+        self.run_callbacks_raw(|callbacks, cb_discrim, data| {
+            if let Some(cb) = callbacks.callbacks.get_mut(&cb_discrim) {
+                cb(data);
+            }
+            let cb_result = unsafe { CallbackResult::from_raw(cb_discrim, data) };
+            if let Some(cb_result) = cb_result {
+                callback_handler(cb_result);
+            }
+        });
+    }
+
+    fn run_callbacks_raw(
+        &self,
+        mut callback_handler: impl FnMut(&mut Callbacks, i32, *mut c_void),
+    ) {
         unsafe {
             let pipe = self.inner.manager.get_pipe();
             sys::SteamAPI_ManualDispatch_RunFrame(pipe);
@@ -237,9 +270,11 @@ impl Client {
                         }
                     }
                 } else {
-                    if let Some(cb) = callbacks.callbacks.get_mut(&callback.m_iCallback) {
-                        cb(callback.m_pubParam as *mut _);
-                    }
+                    callback_handler(
+                        &mut callbacks,
+                        callback.m_iCallback,
+                        callback.m_pubParam as *mut _,
+                    );
                 }
                 sys::SteamAPI_ManualDispatch_FreeLastCallback(pipe);
             }
@@ -249,8 +284,15 @@ impl Client {
     /// Registers the passed function as a callback for the
     /// given type.
     ///
-    /// The callback will be run on the thread that `run_callbacks`
+    /// The callback will be run on the thread that [`run_callbacks`]
     /// is called when the event arrives.
+    /// 
+    /// If the callback handler cannot be made `Send` or `'static`
+    /// the call to [`run_callbacks`] should be replaced with a call to
+    /// [`process_callbacks`] instead.
+    /// 
+    /// [`run_callbacks`]: Self::run_callbacks
+    /// [`process_callbacks`]: Self::proceses_callbacks
     pub fn register_callback<C, F>(&self, f: F) -> CallbackHandle
     where
         C: Callback,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ impl Client {
     /// Runs any currently pending callbacks.
     ///
     /// This is identical to `run_callbacks` in every way, except that
-    /// `callback_handler` is called for every callback invoked. 
+    /// `callback_handler` is called for every callback invoked.
     ///
     /// This option provides an alternative for handling callbacks that
     /// can doesn't require the handler to be `Send`, and `'static`.
@@ -286,11 +286,11 @@ impl Client {
     ///
     /// The callback will be run on the thread that [`run_callbacks`]
     /// is called when the event arrives.
-    /// 
+    ///
     /// If the callback handler cannot be made `Send` or `'static`
     /// the call to [`run_callbacks`] should be replaced with a call to
     /// [`process_callbacks`] instead.
-    /// 
+    ///
     /// [`run_callbacks`]: Self::run_callbacks
     /// [`process_callbacks`]: Self::proceses_callbacks
     pub fn register_callback<C, F>(&self, f: F) -> CallbackHandle


### PR DESCRIPTION
Resolves #125. Implements `Client::process_callbacks` that allows taking a non-'static and/or non-Send function to handle callbacks instead of relying on handlers stored in `Callbacks`.