### PR TITLE
Remove unnecessary generics

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,12 +11,12 @@ impl From<u32> for AppId {
 }
 
 /// Access to the steam apps interface
-pub struct Apps<Manager> {
+pub struct Apps {
     pub(crate) apps: *mut sys::ISteamApps,
-    pub(crate) _inner: Arc<Inner<Manager>>,
+    pub(crate) _inner: Arc<Inner>,
 }
 
-impl<Manager> Apps<Manager> {
+impl Apps {
     /// Returns whether the user currently has the app with the given
     /// ID currently installed.
     ///

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -80,12 +80,12 @@ pub enum OverlayToStoreFlag {
 }
 
 /// Access to the steam friends interface
-pub struct Friends<Manager> {
+pub struct Friends {
     pub(crate) friends: *mut sys::ISteamFriends,
-    pub(crate) inner: Arc<Inner<Manager>>,
+    pub(crate) inner: Arc<Inner>,
 }
 
-impl<Manager> Friends<Manager> {
+impl Friends {
     /// Returns the (display) name of the current user
     pub fn name(&self) -> String {
         unsafe {
@@ -95,7 +95,7 @@ impl<Manager> Friends<Manager> {
         }
     }
 
-    pub fn get_friends(&self, flags: FriendFlags) -> Vec<Friend<Manager>> {
+    pub fn get_friends(&self, flags: FriendFlags) -> Vec<Friend> {
         unsafe {
             let count = sys::SteamAPI_ISteamFriends_GetFriendCount(self.friends, flags.bits() as _);
             if count == -1 {
@@ -115,7 +115,7 @@ impl<Manager> Friends<Manager> {
         }
     }
     /// Returns recently played with players list
-    pub fn get_coplay_friends(&self) -> Vec<Friend<Manager>> {
+    pub fn get_coplay_friends(&self) -> Vec<Friend> {
         unsafe {
             let count = sys::SteamAPI_ISteamFriends_GetCoplayFriendCount(self.friends);
             if count == -1 {
@@ -133,7 +133,7 @@ impl<Manager> Friends<Manager> {
         }
     }
 
-    pub fn get_friend(&self, friend: SteamId) -> Friend<Manager> {
+    pub fn get_friend(&self, friend: SteamId) -> Friend {
         Friend {
             id: friend,
             friends: self.friends,
@@ -316,19 +316,19 @@ unsafe impl Callback for GameLobbyJoinRequested {
     }
 }
 
-pub struct Friend<Manager> {
+pub struct Friend {
     id: SteamId,
     friends: *mut sys::ISteamFriends,
-    _inner: Arc<Inner<Manager>>,
+    _inner: Arc<Inner>,
 }
 
-impl<Manager> Debug for Friend<Manager> {
+impl Debug for Friend {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "Friend({:?})", self.id)
     }
 }
 
-impl<Manager> Friend<Manager> {
+impl Friend {
     pub fn id(&self) -> SteamId {
         self.id
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,9 +3,9 @@ use sys::InputHandle_t;
 use super::*;
 
 /// Access to the steam input interface
-pub struct Input<Manager> {
+pub struct Input {
     pub(crate) input: *mut sys::ISteamInput,
-    pub(crate) _inner: Arc<Inner<Manager>>,
+    pub(crate) _inner: Arc<Inner>,
 }
 
 pub enum InputType {
@@ -26,7 +26,7 @@ pub enum InputType {
     SteamDeckController,
 }
 
-impl<Manager> Input<Manager> {
+impl Input {
     /// Init must be called when starting use of this interface.
     /// if explicitly_call_run_frame is called then you will need to manually call RunFrame
     /// each frame, otherwise Steam Input will updated when SteamAPI_RunCallbacks() is called

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,11 +74,11 @@ pub type SIResult<T> = Result<T, SteamAPIInitError>;
 ///
 /// This provides access to all of the steamworks api that
 /// clients can use.
-pub struct Client<Manager = ClientManager> {
-    inner: Arc<Inner<Manager>>,
+pub struct Client {
+    inner: Arc<Inner>,
 }
 
-impl<Manager> Clone for Client<Manager> {
+impl Clone for Client {
     fn clone(&self) -> Self {
         Client {
             inner: self.inner.clone(),
@@ -86,10 +86,10 @@ impl<Manager> Clone for Client<Manager> {
     }
 }
 
-struct Inner<Manager> {
-    _manager: Manager,
+struct Inner {
+    manager: Box<dyn Manager>,
     callbacks: Mutex<Callbacks>,
-    networking_sockets_data: Mutex<NetworkingSocketsData<Manager>>,
+    networking_sockets_data: Mutex<NetworkingSocketsData>,
 }
 
 struct Callbacks {
@@ -97,23 +97,23 @@ struct Callbacks {
     call_results: HashMap<sys::SteamAPICall_t, Box<dyn FnOnce(*mut c_void, bool) + Send + 'static>>,
 }
 
-struct NetworkingSocketsData<Manager> {
+struct NetworkingSocketsData {
     sockets: HashMap<
         sys::HSteamListenSocket,
         (
-            Weak<networking_sockets::InnerSocket<Manager>>,
-            Sender<networking_types::ListenSocketEvent<Manager>>,
+            Weak<networking_sockets::InnerSocket>,
+            Sender<networking_types::ListenSocketEvent>,
         ),
     >,
     /// Connections to a remote listening port
     independent_connections: HashMap<sys::HSteamNetConnection, Sender<()>>,
-    connection_callback: Weak<CallbackHandle<Manager>>,
+    connection_callback: Weak<CallbackHandle>,
 }
 
-unsafe impl<Manager: Send + Sync> Send for Inner<Manager> {}
-unsafe impl<Manager: Send + Sync> Sync for Inner<Manager> {}
-unsafe impl<Manager: Send + Sync> Send for Client<Manager> {}
-unsafe impl<Manager: Send + Sync> Sync for Client<Manager> {}
+unsafe impl Send for Inner {}
+unsafe impl Sync for Inner {}
+unsafe impl Send for Client {}
+unsafe impl Sync for Client {}
 
 /// Returns true if the app wasn't launched through steam and
 /// begins relaunching it, the app should exit as soon as possible.
@@ -131,7 +131,7 @@ where
 {
 }
 
-impl Client<ClientManager> {
+impl Client {
     /// Call to the native SteamAPI_Init function.
     /// should not be used directly, but through either
     /// init_flat() or init_flat_app()
@@ -158,9 +158,9 @@ impl Client<ClientManager> {
     /// * The game isn't running on the same user/level as the steam client
     /// * The user doesn't own a license for the game.
     /// * The app ID isn't completely set up.
-    pub fn init() -> SIResult<Client<ClientManager>> {
-        static_assert_send::<Client<ClientManager>>();
-        static_assert_sync::<Client<ClientManager>>();
+    pub fn init() -> SIResult<Client> {
+        static_assert_send::<Client>();
+        static_assert_sync::<Client>();
         unsafe {
             let mut err_msg: sys::SteamErrMsg = [0; 1024];
             let result = Self::steam_api_init_flat(&mut err_msg);
@@ -171,7 +171,7 @@ impl Client<ClientManager> {
 
             sys::SteamAPI_ManualDispatch_Init();
             let client = Arc::new(Inner {
-                _manager: ClientManager { _priv: () },
+                manager: Box::new(ClientManager),
                 callbacks: Mutex::new(Callbacks {
                     callbacks: HashMap::new(),
                     call_results: HashMap::new(),
@@ -199,7 +199,7 @@ impl Client<ClientManager> {
     /// * The game isn't running on the same user/level as the steam client
     /// * The user doesn't own a license for the game.
     /// * The app ID isn't completely set up.
-    pub fn init_app<ID: Into<AppId>>(app_id: ID) -> SIResult<Client<ClientManager>> {
+    pub fn init_app<ID: Into<AppId>>(app_id: ID) -> SIResult<Client> {
         let app_id = app_id.into().0.to_string();
         std::env::set_var("SteamAppId", &app_id);
         std::env::set_var("SteamGameId", app_id);
@@ -207,10 +207,7 @@ impl Client<ClientManager> {
     }
 }
 
-impl<Manager> Client<Manager>
-where
-    Manager: crate::Manager,
-{
+impl Client {
     /// Runs any currently pending callbacks
     ///
     /// This runs all currently pending callbacks on the current
@@ -220,7 +217,7 @@ where
     /// in order to reduce the latency between recieving events.
     pub fn run_callbacks(&self) {
         unsafe {
-            let pipe = Manager::get_pipe();
+            let pipe = self.inner.manager.get_pipe();
             sys::SteamAPI_ManualDispatch_RunFrame(pipe);
             let mut callback = std::mem::zeroed();
             while sys::SteamAPI_ManualDispatch_GetNextCallback(pipe, &mut callback) {
@@ -259,7 +256,7 @@ where
     ///
     /// The callback will be run on the thread that `run_callbacks`
     /// is called when the event arrives.
-    pub fn register_callback<C, F>(&self, f: F) -> CallbackHandle<Manager>
+    pub fn register_callback<C, F>(&self, f: F) -> CallbackHandle
     where
         C: Callback,
         F: FnMut(C) + 'static + Send,
@@ -268,7 +265,7 @@ where
     }
 
     /// Returns an accessor to the steam utils interface
-    pub fn utils(&self) -> Utils<Manager> {
+    pub fn utils(&self) -> Utils {
         unsafe {
             let utils = sys::SteamAPI_SteamUtils_v010();
             debug_assert!(!utils.is_null());
@@ -280,7 +277,7 @@ where
     }
 
     /// Returns an accessor to the steam matchmaking interface
-    pub fn matchmaking(&self) -> Matchmaking<Manager> {
+    pub fn matchmaking(&self) -> Matchmaking {
         unsafe {
             let mm = sys::SteamAPI_SteamMatchmaking_v009();
             debug_assert!(!mm.is_null());
@@ -292,7 +289,7 @@ where
     }
 
     /// Returns an accessor to the steam matchmaking_servers interface
-    pub fn matchmaking_servers(&self) -> MatchmakingServers<Manager> {
+    pub fn matchmaking_servers(&self) -> MatchmakingServers {
         unsafe {
             let mm = sys::SteamAPI_SteamMatchmakingServers_v002();
             debug_assert!(!mm.is_null());
@@ -304,7 +301,7 @@ where
     }
 
     /// Returns an accessor to the steam networking interface
-    pub fn networking(&self) -> Networking<Manager> {
+    pub fn networking(&self) -> Networking {
         unsafe {
             let net = sys::SteamAPI_SteamNetworking_v006();
             debug_assert!(!net.is_null());
@@ -316,7 +313,7 @@ where
     }
 
     /// Returns an accessor to the steam apps interface
-    pub fn apps(&self) -> Apps<Manager> {
+    pub fn apps(&self) -> Apps {
         unsafe {
             let apps = sys::SteamAPI_SteamApps_v008();
             debug_assert!(!apps.is_null());
@@ -328,7 +325,7 @@ where
     }
 
     /// Returns an accessor to the steam friends interface
-    pub fn friends(&self) -> Friends<Manager> {
+    pub fn friends(&self) -> Friends {
         unsafe {
             let friends = sys::SteamAPI_SteamFriends_v017();
             debug_assert!(!friends.is_null());
@@ -340,7 +337,7 @@ where
     }
 
     /// Returns an accessor to the steam input interface
-    pub fn input(&self) -> Input<Manager> {
+    pub fn input(&self) -> Input {
         unsafe {
             let input = sys::SteamAPI_SteamInput_v006();
             debug_assert!(!input.is_null());
@@ -352,7 +349,7 @@ where
     }
 
     /// Returns an accessor to the steam user interface
-    pub fn user(&self) -> User<Manager> {
+    pub fn user(&self) -> User {
         unsafe {
             let user = sys::SteamAPI_SteamUser_v023();
             debug_assert!(!user.is_null());
@@ -364,7 +361,7 @@ where
     }
 
     /// Returns an accessor to the steam user stats interface
-    pub fn user_stats(&self) -> UserStats<Manager> {
+    pub fn user_stats(&self) -> UserStats {
         unsafe {
             let us = sys::SteamAPI_SteamUserStats_v012();
             debug_assert!(!us.is_null());
@@ -376,7 +373,7 @@ where
     }
 
     /// Returns an accessor to the steam remote play interface
-    pub fn remote_play(&self) -> RemotePlay<Manager> {
+    pub fn remote_play(&self) -> RemotePlay {
         unsafe {
             let rp = sys::SteamAPI_SteamRemotePlay_v002();
             debug_assert!(!rp.is_null());
@@ -388,7 +385,7 @@ where
     }
 
     /// Returns an accessor to the steam remote storage interface
-    pub fn remote_storage(&self) -> RemoteStorage<Manager> {
+    pub fn remote_storage(&self) -> RemoteStorage {
         unsafe {
             let rs = sys::SteamAPI_SteamRemoteStorage_v016();
             debug_assert!(!rs.is_null());
@@ -403,7 +400,7 @@ where
     }
 
     /// Returns an accessor to the steam screenshots interface
-    pub fn screenshots(&self) -> Screenshots<Manager> {
+    pub fn screenshots(&self) -> Screenshots {
         unsafe {
             let screenshots = sys::SteamAPI_SteamScreenshots_v003();
             debug_assert!(!screenshots.is_null());
@@ -415,7 +412,7 @@ where
     }
 
     /// Returns an accessor to the steam UGC interface (steam workshop)
-    pub fn ugc(&self) -> UGC<Manager> {
+    pub fn ugc(&self) -> UGC {
         unsafe {
             let ugc = sys::SteamAPI_SteamUGC_v020();
             debug_assert!(!ugc.is_null());
@@ -427,7 +424,7 @@ where
     }
 
     /// Returns an accessor to the steam timeline interface
-    pub fn timeline(&self) -> Timeline<Manager> {
+    pub fn timeline(&self) -> Timeline {
         unsafe {
             let timeline = sys::SteamAPI_SteamTimeline_v001();
 
@@ -439,7 +436,7 @@ where
         }
     }
 
-    pub fn networking_messages(&self) -> networking_messages::NetworkingMessages<Manager> {
+    pub fn networking_messages(&self) -> networking_messages::NetworkingMessages {
         unsafe {
             let net = sys::SteamAPI_SteamNetworkingMessages_SteamAPI_v002();
             debug_assert!(!net.is_null());
@@ -450,7 +447,7 @@ where
         }
     }
 
-    pub fn networking_sockets(&self) -> networking_sockets::NetworkingSockets<Manager> {
+    pub fn networking_sockets(&self) -> networking_sockets::NetworkingSockets {
         unsafe {
             let sockets = sys::SteamAPI_SteamNetworkingSockets_SteamAPI_v012();
             debug_assert!(!sockets.is_null());
@@ -461,7 +458,7 @@ where
         }
     }
 
-    pub fn networking_utils(&self) -> networking_utils::NetworkingUtils<Manager> {
+    pub fn networking_utils(&self) -> networking_utils::NetworkingUtils {
         unsafe {
             let utils = sys::SteamAPI_SteamNetworkingUtils_SteamAPI_v004();
             debug_assert!(!utils.is_null());
@@ -474,17 +471,15 @@ where
 }
 
 /// Used to separate client and game server modes
-pub unsafe trait Manager {
-    unsafe fn get_pipe() -> sys::HSteamPipe;
+trait Manager {
+    unsafe fn get_pipe(&self) -> sys::HSteamPipe;
 }
 
 /// Manages keeping the steam api active for clients
-pub struct ClientManager {
-    _priv: (),
-}
+struct ClientManager;
 
-unsafe impl Manager for ClientManager {
-    unsafe fn get_pipe() -> sys::HSteamPipe {
+impl Manager for ClientManager {
+    unsafe fn get_pipe(&self) -> sys::HSteamPipe {
         sys::SteamAPI_GetHSteamPipe()
     }
 }

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -5,9 +5,9 @@ use super::*;
 use serial_test::serial;
 
 /// Access to the steam matchmaking interface
-pub struct Matchmaking<Manager> {
+pub struct Matchmaking {
     pub(crate) mm: *mut sys::ISteamMatchmaking,
-    pub(crate) inner: Arc<Inner<Manager>>,
+    pub(crate) inner: Arc<Inner>,
 }
 
 const CALLBACK_BASE_ID: i32 = 500;
@@ -44,14 +44,14 @@ impl LobbyId {
     }
 }
 
-impl<Manager> Matchmaking<Manager> {
+impl Matchmaking {
     pub fn request_lobby_list<F>(&self, cb: F)
     where
         F: FnOnce(SResult<Vec<LobbyId>>) + 'static + Send,
     {
         unsafe {
             let api_call = sys::SteamAPI_ISteamMatchmaking_RequestLobbyList(self.mm);
-            register_call_result::<sys::LobbyMatchList_t, _, _>(
+            register_call_result::<sys::LobbyMatchList_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_BASE_ID + 10,
@@ -97,7 +97,7 @@ impl<Manager> Matchmaking<Manager> {
             };
             let api_call =
                 sys::SteamAPI_ISteamMatchmaking_CreateLobby(self.mm, ty, max_members as _);
-            register_call_result::<sys::LobbyCreated_t, _, _>(
+            register_call_result::<sys::LobbyCreated_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_BASE_ID + 13,
@@ -121,7 +121,7 @@ impl<Manager> Matchmaking<Manager> {
     {
         unsafe {
             let api_call = sys::SteamAPI_ISteamMatchmaking_JoinLobby(self.mm, lobby.0);
-            register_call_result::<sys::LobbyEnter_t, _, _>(
+            register_call_result::<sys::LobbyEnter_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_BASE_ID + 4,

--- a/src/matchmaking_servers.rs
+++ b/src/matchmaking_servers.rs
@@ -438,12 +438,12 @@ impl ServerListRequest {
 }
 
 /// Access to the steam MatchmakingServers interface
-pub struct MatchmakingServers<Manager> {
+pub struct MatchmakingServers {
     pub(crate) mms: *mut sys::ISteamMatchmakingServers,
-    pub(crate) _inner: Arc<Inner<Manager>>,
+    pub(crate) _inner: Arc<Inner>,
 }
 
-impl<Manager> MatchmakingServers<Manager> {
+impl MatchmakingServers {
     pub fn ping_server(&self, ip: std::net::Ipv4Addr, port: u16, callbacks: PingCallbacks) {
         unsafe {
             let callbacks = create_ping(callbacks);

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -6,9 +6,9 @@
 use super::*;
 
 /// Access to the steam networking interface
-pub struct Networking<Manager> {
+pub struct Networking {
     pub(crate) net: *mut sys::ISteamNetworking,
-    pub(crate) _inner: Arc<Inner<Manager>>,
+    pub(crate) _inner: Arc<Inner>,
 }
 
 /// The method used to send a packet
@@ -31,7 +31,7 @@ pub enum SendType {
     ReliableWithBuffering,
 }
 
-impl<Manager> Networking<Manager> {
+impl Networking {
     /// Accepts incoming packets from the given user
     ///
     /// Should only be called in response to a `P2PSessionRequest`.

--- a/src/networking_sockets.rs
+++ b/src/networking_sockets.rs
@@ -398,9 +398,6 @@ pub struct ListenSocket {
     receiver: Receiver<ListenSocketEvent>,
 }
 
-unsafe impl Send for ListenSocket {}
-unsafe impl Sync for ListenSocket {}
-
 impl ListenSocket {
     pub(crate) fn new(
         handle: sys::HSteamListenSocket,
@@ -511,6 +508,9 @@ pub(crate) struct InnerSocket {
     pub(crate) handle: sys::HSteamListenSocket,
     pub(crate) inner: Arc<Inner>,
 }
+
+unsafe impl Send for InnerSocket {}
+unsafe impl Sync for InnerSocket {}
 
 impl Drop for InnerSocket {
     fn drop(&mut self) {

--- a/src/networking_sockets_callback.rs
+++ b/src/networking_sockets_callback.rs
@@ -10,10 +10,10 @@ use sys::ISteamNetworkingSockets;
 /// All independent connections (to a remote host) and listening sockets share the same Callback for
 /// `NetConnectionStatusChangedCallback`. This function either returns the existing handle, or creates a new
 /// handler.
-pub(crate) fn get_or_create_connection_callback<Manager: 'static>(
-    inner: Arc<Inner<Manager>>,
+pub(crate) fn get_or_create_connection_callback(
+    inner: Arc<Inner>,
     sockets: *mut ISteamNetworkingSockets,
-) -> Arc<CallbackHandle<Manager>> {
+) -> Arc<CallbackHandle> {
     let mut network_socket_data = inner.networking_sockets_data.lock().unwrap();
     if let Some(callback) = network_socket_data.connection_callback.upgrade() {
         callback
@@ -34,15 +34,15 @@ pub(crate) fn get_or_create_connection_callback<Manager: 'static>(
     }
 }
 
-pub(crate) struct ConnectionCallbackHandler<Manager> {
-    inner: Weak<Inner<Manager>>,
+pub(crate) struct ConnectionCallbackHandler {
+    inner: Weak<Inner>,
     sockets: *mut ISteamNetworkingSockets,
 }
 
-unsafe impl<Manager> Send for ConnectionCallbackHandler<Manager> {}
-unsafe impl<Manager> Sync for ConnectionCallbackHandler<Manager> {}
+unsafe impl Send for ConnectionCallbackHandler {}
+unsafe impl Sync for ConnectionCallbackHandler {}
 
-impl<Manager: 'static> ConnectionCallbackHandler<Manager> {
+impl ConnectionCallbackHandler {
     pub(crate) fn callback(&self, event: NetConnectionStatusChanged) {
         if let Some(socket) = event.connection_info.listen_socket() {
             self.listen_socket_callback(socket, event);

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1428,10 +1428,10 @@ unsafe impl Callback for NetConnectionStatusChanged {
 }
 
 impl NetConnectionStatusChanged {
-    pub(crate) fn into_listen_socket_event<Manager: 'static>(
+    pub(crate) fn into_listen_socket_event(
         self,
-        socket: Arc<InnerSocket<Manager>>,
-    ) -> Result<ListenSocketEvent<Manager>, NetConnectionError> {
+        socket: Arc<InnerSocket>,
+    ) -> Result<ListenSocketEvent, NetConnectionError> {
         match self.connection_info.state() {
             Ok(NetworkingConnectionState::None) => {
                 Err(UnhandledType(NetworkingConnectionState::None))
@@ -1491,19 +1491,19 @@ impl NetConnectionStatusChanged {
     }
 }
 
-pub enum ListenSocketEvent<Manager> {
-    Connecting(ConnectionRequest<Manager>),
-    Connected(ConnectedEvent<Manager>),
+pub enum ListenSocketEvent {
+    Connecting(ConnectionRequest),
+    Connected(ConnectedEvent),
     Disconnected(DisconnectedEvent),
 }
 
-pub struct ConnectionRequest<Manager> {
+pub struct ConnectionRequest {
     remote: NetworkingIdentity,
     user_data: i64,
-    connection: NetConnection<Manager>,
+    connection: NetConnection,
 }
 
-impl<Manager: 'static> ConnectionRequest<Manager> {
+impl ConnectionRequest {
     pub fn remote(&self) -> NetworkingIdentity {
         self.remote.clone()
     }
@@ -1521,24 +1521,24 @@ impl<Manager: 'static> ConnectionRequest<Manager> {
     }
 }
 
-pub struct ConnectedEvent<Manager> {
+pub struct ConnectedEvent {
     remote: NetworkingIdentity,
     user_data: i64,
-    connection: NetConnection<Manager>,
+    connection: NetConnection,
 }
 
-impl<Manager> ConnectedEvent<Manager> {
+impl ConnectedEvent {
     pub fn remote(&self) -> NetworkingIdentity {
         self.remote.clone()
     }
     pub fn user_data(&self) -> i64 {
         self.user_data
     }
-    pub fn connection(&self) -> &NetConnection<Manager> {
+    pub fn connection(&self) -> &NetConnection {
         &self.connection
     }
 
-    pub fn take_connection(self) -> NetConnection<Manager> {
+    pub fn take_connection(self) -> NetConnection {
         self.connection
     }
 }
@@ -1811,14 +1811,14 @@ impl Default for NetworkingIdentity {
     }
 }
 
-pub struct NetworkingMessage<Manager> {
+pub struct NetworkingMessage {
     pub(crate) message: *mut sys::SteamNetworkingMessage_t,
 
     // Not sure if this is necessary here, we may not need a Manager to use free on messages
-    pub(crate) _inner: Arc<Inner<Manager>>,
+    pub(crate) _inner: Arc<Inner>,
 }
 
-impl<Manager> NetworkingMessage<Manager> {
+impl NetworkingMessage {
     /// For messages received on connections: what connection did this come from?
     /// For outgoing messages: what connection to send it to?
     /// Not used when using the ISteamNetworkingMessages interface
@@ -1836,7 +1836,7 @@ impl<Manager> NetworkingMessage<Manager> {
     /// Make sure you don't close or drop the `NetConnection` before sending your message.
     ///
     /// Use this with `ListenSocket::send_messages` for efficient sending.
-    pub fn set_connection(&mut self, connection: &NetConnection<Manager>) {
+    pub fn set_connection(&mut self, connection: &NetConnection) {
         unsafe { (*self.message).m_conn = connection.handle }
     }
 
@@ -1993,7 +1993,7 @@ extern "C" fn free_rust_message_buffer(message: *mut sys::SteamNetworkingMessage
     }
 }
 
-impl<Manager> Drop for NetworkingMessage<Manager> {
+impl Drop for NetworkingMessage {
     fn drop(&mut self) {
         if !self.message.is_null() {
             unsafe { sys::SteamAPI_SteamNetworkingMessage_t_Release(self.message) }

--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -7,15 +7,15 @@ use std::sync::Arc;
 use steamworks_sys as sys;
 
 /// Access to the steam networking sockets interface
-pub struct NetworkingUtils<Manager> {
+pub struct NetworkingUtils {
     pub(crate) utils: *mut sys::ISteamNetworkingUtils,
-    pub(crate) inner: Arc<Inner<Manager>>,
+    pub(crate) inner: Arc<Inner>,
 }
 
-unsafe impl<T> Send for NetworkingUtils<T> {}
-unsafe impl<T> Sync for NetworkingUtils<T> {}
+unsafe impl Send for NetworkingUtils {}
+unsafe impl Sync for NetworkingUtils {}
 
-impl<Manager> NetworkingUtils<Manager> {
+impl NetworkingUtils {
     /// Allocate and initialize a message object.  Usually the reason
     /// you call this is to pass it to ISteamNetworkingSockets::SendMessages.
     /// The returned object will have all of the relevant fields cleared to zero.
@@ -30,7 +30,7 @@ impl<Manager> NetworkingUtils<Manager> {
     /// If cbAllocateBuffer=0, then no buffer is allocated.  m_pData will be NULL,
     /// m_cbSize will be zero, and m_pfnFreeData will be NULL.  You will need to
     /// set each of these.
-    pub fn allocate_message(&self, buffer_size: usize) -> NetworkingMessage<Manager> {
+    pub fn allocate_message(&self, buffer_size: usize) -> NetworkingMessage {
         unsafe {
             let message =
                 sys::SteamAPI_ISteamNetworkingUtils_AllocateMessage(self.utils, buffer_size as _);

--- a/src/remote_play.rs
+++ b/src/remote_play.rs
@@ -1,11 +1,11 @@
 use super::*;
 
-pub struct RemotePlay<Manager> {
+pub struct RemotePlay {
     pub(crate) rp: *mut sys::ISteamRemotePlay,
-    pub(crate) inner: Arc<Inner<Manager>>,
+    pub(crate) inner: Arc<Inner>,
 }
 
-impl<Manager> Clone for RemotePlay<Manager> {
+impl Clone for RemotePlay {
     fn clone(&self) -> Self {
         RemotePlay {
             inner: self.inner.clone(),
@@ -14,9 +14,9 @@ impl<Manager> Clone for RemotePlay<Manager> {
     }
 }
 
-impl<Manager> RemotePlay<Manager> {
+impl RemotePlay {
     /// Return a list of all active Remote Play sessions
-    pub fn sessions(&self) -> Vec<RemotePlaySession<Manager>> {
+    pub fn sessions(&self) -> Vec<RemotePlaySession> {
         unsafe {
             let count = sys::SteamAPI_ISteamRemotePlay_GetSessionCount(self.rp);
             let mut sessions = Vec::with_capacity(count as usize);
@@ -37,7 +37,7 @@ impl<Manager> RemotePlay<Manager> {
     }
 
     /// Get a remote play session from a session ID. The session may or may not be valid or active
-    pub fn session(&self, session: RemotePlaySessionId) -> RemotePlaySession<Manager> {
+    pub fn session(&self, session: RemotePlaySessionId) -> RemotePlaySession {
         RemotePlaySession {
             session,
             rp: self.rp,
@@ -68,10 +68,10 @@ impl RemotePlaySessionId {
     }
 }
 
-pub struct RemotePlaySession<Manager> {
+pub struct RemotePlaySession {
     session: RemotePlaySessionId,
     pub(crate) rp: *mut sys::ISteamRemotePlay,
-    pub(crate) _inner: Arc<Inner<Manager>>,
+    pub(crate) _inner: Arc<Inner>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -82,7 +82,7 @@ pub enum SteamDeviceFormFactor {
     TV,
 }
 
-impl<Manager> RemotePlaySession<Manager> {
+impl RemotePlaySession {
     /// Get the user associated with this Remote Play session. This is either the logged in user or a friend when Remote
     /// Playing Together.
     pub fn user(&self) -> SteamId {

--- a/src/screenshots.rs
+++ b/src/screenshots.rs
@@ -5,12 +5,12 @@ pub use sys::ScreenshotHandle;
 use super::*;
 
 /// Access to the steam screenshots interface
-pub struct Screenshots<Manager> {
+pub struct Screenshots {
     pub(crate) screenshots: *mut sys::ISteamScreenshots,
-    pub(crate) _inner: Arc<Inner<Manager>>,
+    pub(crate) _inner: Arc<Inner>,
 }
 
-impl<Manager> Screenshots<Manager> {
+impl Screenshots {
     /// Toggles whether the overlay handles screenshots when the user presses the screenshot hotkey, or if the game handles them.
     ///
     /// Hooking is disabled by default, and only ever enabled if you do so with this function.

--- a/src/server.rs
+++ b/src/server.rs
@@ -505,15 +505,17 @@ fn test() {
 struct ServerManager;
 
 impl Manager for ServerManager {
-    unsafe fn get_pipe(&self) -> sys::HSteamPipe {
-        sys::SteamGameServer_GetHSteamPipe()
+    fn get_pipe(&self) -> sys::HSteamPipe {
+        // SAFETY: This is considered unsafe only because of FFI, the function is otherwise
+        // always safe to call from any thread.
+        unsafe { sys::SteamGameServer_GetHSteamPipe() }
     }
 }
 
 impl Drop for ServerManager {
     fn drop(&mut self) {
-        unsafe {
-            sys::SteamGameServer_Shutdown();
-        }
+        // SAFETY: This is considered unsafe only because of FFI, the function is otherwise
+        // always safe to call from any thread.
+        unsafe { sys::SteamGameServer_Shutdown() }
     }
 }

--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -1,11 +1,11 @@
 use super::*;
 use std::time::Duration;
 
-pub struct Timeline<Manager> {
+pub struct Timeline {
     pub(crate) timeline: *mut sys::ISteamTimeline,
     /// Whether the client's steam API is not recent enough.
     pub(crate) disabled: bool,
-    pub(crate) _inner: Arc<Inner<Manager>>,
+    pub(crate) _inner: Arc<Inner>,
 }
 
 pub enum TimelineGameMode {
@@ -58,7 +58,7 @@ impl From<TimelineEventClipPriority> for sys::ETimelineEventClipPriority {
     }
 }
 
-impl<Manager> Timeline<Manager> {
+impl Timeline {
     /// Changes the color of the timeline bar.
     pub fn set_timeline_game_mode(&self, mode: TimelineGameMode) {
         if self.disabled {

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -10,9 +10,9 @@ use std::path::Path;
 
 pub const RESULTS_PER_PAGE: u32 = sys::kNumUGCResultsPerPage as u32;
 
-pub struct UGC<Manager> {
+pub struct UGC {
     pub(crate) ugc: *mut sys::ISteamUGC,
-    pub(crate) inner: Arc<Inner<Manager>>,
+    pub(crate) inner: Arc<Inner>,
 }
 
 const CALLBACK_BASE_ID: i32 = 3400;
@@ -517,7 +517,7 @@ pub struct InstallInfo {
     pub timestamp: u32,
 }
 
-impl<Manager> UGC<Manager> {
+impl UGC {
     /// Suspends or resumes all workshop downloads
     pub fn suspend_downloads(&self, suspend: bool) {
         unsafe {
@@ -532,7 +532,7 @@ impl<Manager> UGC<Manager> {
     {
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_CreateItem(self.ugc, app_id.0, file_type.into());
-            register_call_result::<sys::CreateItemResult_t, _, _>(
+            register_call_result::<sys::CreateItemResult_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_BASE_ID + 3,
@@ -554,11 +554,7 @@ impl<Manager> UGC<Manager> {
 
     /// Starts an item update process
     #[must_use]
-    pub fn start_item_update(
-        &self,
-        app_id: AppId,
-        file_id: PublishedFileId,
-    ) -> UpdateHandle<Manager> {
+    pub fn start_item_update(&self, app_id: AppId, file_id: PublishedFileId) -> UpdateHandle {
         unsafe {
             let handle = sys::SteamAPI_ISteamUGC_StartItemUpdate(self.ugc, app_id.0, file_id.0);
             UpdateHandle {
@@ -577,7 +573,7 @@ impl<Manager> UGC<Manager> {
     {
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_SubscribeItem(self.ugc, published_file_id.0);
-            register_call_result::<sys::RemoteStorageSubscribePublishedFileResult_t, _, _>(
+            register_call_result::<sys::RemoteStorageSubscribePublishedFileResult_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_REMOTE_STORAGE_BASE_ID + 13,
@@ -600,7 +596,7 @@ impl<Manager> UGC<Manager> {
     {
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_UnsubscribeItem(self.ugc, published_file_id.0);
-            register_call_result::<sys::RemoteStorageUnsubscribePublishedFileResult_t, _, _>(
+            register_call_result::<sys::RemoteStorageUnsubscribePublishedFileResult_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_REMOTE_STORAGE_BASE_ID + 15,
@@ -690,7 +686,7 @@ impl<Manager> UGC<Manager> {
         item_type: UGCType,
         appids: AppIDs,
         page: u32,
-    ) -> Result<QueryHandle<Manager>, CreateQueryError> {
+    ) -> Result<QueryHandle, CreateQueryError> {
         // Call the external function with the correct parameters
         let handle = unsafe {
             sys::SteamAPI_ISteamUGC_CreateQueryAllUGCRequestPage(
@@ -725,7 +721,7 @@ impl<Manager> UGC<Manager> {
         sort_order: UserListOrder,
         appids: AppIDs,
         page: u32,
-    ) -> Result<QueryHandle<Manager>, CreateQueryError> {
+    ) -> Result<QueryHandle, CreateQueryError> {
         let res = unsafe {
             sys::SteamAPI_ISteamUGC_CreateQueryUserUGCRequest(
                 self.ugc,
@@ -753,7 +749,7 @@ impl<Manager> UGC<Manager> {
     pub fn query_items(
         &self,
         mut items: Vec<PublishedFileId>,
-    ) -> Result<QueryHandle<Manager>, CreateQueryError> {
+    ) -> Result<QueryHandle, CreateQueryError> {
         debug_assert!(items.len() > 0);
 
         let res = unsafe {
@@ -775,10 +771,7 @@ impl<Manager> UGC<Manager> {
         })
     }
 
-    pub fn query_item(
-        &self,
-        item: PublishedFileId,
-    ) -> Result<QueryHandle<Manager>, CreateQueryError> {
+    pub fn query_item(&self, item: PublishedFileId) -> Result<QueryHandle, CreateQueryError> {
         let mut items = vec![item];
 
         let res = unsafe {
@@ -807,7 +800,7 @@ impl<Manager> UGC<Manager> {
     {
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_DeleteItem(self.ugc, published_file_id.0);
-            register_call_result::<sys::DownloadItemResult_t, _, _>(
+            register_call_result::<sys::DownloadItemResult_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_REMOTE_STORAGE_BASE_ID + 17,
@@ -827,7 +820,7 @@ impl<Manager> UGC<Manager> {
     }
 }
 
-impl UGC<ServerManager> {
+impl UGC {
     /// Initialize this UGC interface for a Steam game server.
     ///
     /// You should pass in the Workshop depot, you can find this on SteamDB. It's usually just the app ID.
@@ -848,14 +841,14 @@ impl UGC<ServerManager> {
 }
 
 /// A handle to update a published item
-pub struct UpdateHandle<Manager> {
+pub struct UpdateHandle {
     ugc: *mut sys::ISteamUGC,
-    inner: Arc<Inner<Manager>>,
+    inner: Arc<Inner>,
 
     handle: sys::UGCUpdateHandle_t,
 }
 
-impl<Manager> UpdateHandle<Manager> {
+impl UpdateHandle {
     #[must_use]
     pub fn title(self, title: &str) -> Self {
         unsafe {
@@ -1005,7 +998,7 @@ impl<Manager> UpdateHandle<Manager> {
         self
     }
 
-    pub fn submit<F>(self, change_note: Option<&str>, cb: F) -> UpdateWatchHandle<Manager>
+    pub fn submit<F>(self, change_note: Option<&str>, cb: F) -> UpdateWatchHandle
     where
         F: FnOnce(Result<(PublishedFileId, bool), SteamError>) + 'static + Send,
     {
@@ -1014,7 +1007,7 @@ impl<Manager> UpdateHandle<Manager> {
             let change_note = change_note.and_then(|v| CString::new(v).ok());
             let note = change_note.as_ref().map_or(ptr::null(), |v| v.as_ptr());
             let api_call = sys::SteamAPI_ISteamUGC_SubmitItemUpdate(self.ugc, self.handle, note);
-            register_call_result::<sys::SubmitItemUpdateResult_t, _, _>(
+            register_call_result::<sys::SubmitItemUpdateResult_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_BASE_ID + 4,
@@ -1041,17 +1034,17 @@ impl<Manager> UpdateHandle<Manager> {
 }
 
 /// A handle to watch an update of a published item
-pub struct UpdateWatchHandle<Manager> {
+pub struct UpdateWatchHandle {
     ugc: *mut sys::ISteamUGC,
-    _inner: Arc<Inner<Manager>>,
+    _inner: Arc<Inner>,
 
     handle: sys::UGCUpdateHandle_t,
 }
 
-unsafe impl<Manager> Send for UpdateWatchHandle<Manager> {}
-unsafe impl<Manager> Sync for UpdateWatchHandle<Manager> {}
+unsafe impl Send for UpdateWatchHandle {}
+unsafe impl Sync for UpdateWatchHandle {}
 
-impl<Manager> UpdateWatchHandle<Manager> {
+impl UpdateWatchHandle {
     pub fn progress(&self) -> (UpdateStatus, u64, u64) {
         unsafe {
             let mut progress = 0;
@@ -1097,15 +1090,16 @@ pub enum UpdateStatus {
 }
 
 /// Query handle, to allow for more filtering.
-pub struct QueryHandle<Manager> {
+pub struct QueryHandle {
     ugc: *mut sys::ISteamUGC,
-    inner: Arc<Inner<Manager>>,
+    inner: Arc<Inner>,
 
     // Note: this is always filled except in `fetch`, where it must be taken
     // to prevent the handle from being dropped when this query is dropped.
     handle: Option<sys::UGCQueryHandle_t>,
 }
-impl<Manager> Drop for QueryHandle<Manager> {
+
+impl Drop for QueryHandle {
     fn drop(&mut self) {
         if let Some(handle) = self.handle.as_mut() {
             unsafe {
@@ -1114,7 +1108,8 @@ impl<Manager> Drop for QueryHandle<Manager> {
         }
     }
 }
-impl<Manager> QueryHandle<Manager> {
+
+impl QueryHandle {
     /// Excludes items with a specific tag.
     ///
     /// Panics if `tag` could not be converted to a `CString`.
@@ -1434,7 +1429,7 @@ impl<Manager> QueryHandle<Manager> {
 
         unsafe {
             let api_call = sys::SteamAPI_ISteamUGC_SendQueryUGCRequest(ugc, handle);
-            register_call_result::<sys::SteamUGCQueryCompleted_t, _, _>(
+            register_call_result::<sys::SteamUGCQueryCompleted_t, _>(
                 &inner,
                 api_call,
                 CALLBACK_BASE_ID + 1,

--- a/src/user.rs
+++ b/src/user.rs
@@ -4,12 +4,12 @@ use crate::networking_types::NetworkingIdentity;
 use serial_test::serial;
 
 /// Access to the steam user interface
-pub struct User<Manager> {
+pub struct User {
     pub(crate) user: *mut sys::ISteamUser,
-    pub(crate) _inner: Arc<Inner<Manager>>,
+    pub(crate) _inner: Arc<Inner>,
 }
 
-impl<Manager> User<Manager> {
+impl User {
     /// Returns the steam id of the current user
     pub fn steam_id(&self) -> SteamId {
         unsafe { SteamId(sys::SteamAPI_ISteamUser_GetSteamID(self.user)) }

--- a/src/user_stats.rs
+++ b/src/user_stats.rs
@@ -7,14 +7,14 @@ use super::*;
 use serial_test::serial;
 
 /// Access to the steam user interface
-pub struct UserStats<Manager> {
+pub struct UserStats {
     pub(crate) user_stats: *mut sys::ISteamUserStats,
-    pub(crate) inner: Arc<Inner<Manager>>,
+    pub(crate) inner: Arc<Inner>,
 }
 
 const CALLBACK_BASE_ID: i32 = 1100;
 
-impl<Manager> UserStats<Manager> {
+impl UserStats {
     pub fn find_leaderboard<F>(&self, name: &str, cb: F)
     where
         F: FnOnce(Result<Option<Leaderboard>, SteamError>) + 'static + Send,
@@ -25,7 +25,7 @@ impl<Manager> UserStats<Manager> {
                 self.user_stats,
                 name.as_ptr() as *const _,
             );
-            register_call_result::<sys::LeaderboardFindResult_t, _, _>(
+            register_call_result::<sys::LeaderboardFindResult_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_BASE_ID + 4,
@@ -83,7 +83,7 @@ impl<Manager> UserStats<Manager> {
                 sort_method,
                 display_type,
             );
-            register_call_result::<sys::LeaderboardFindResult_t, _, _>(
+            register_call_result::<sys::LeaderboardFindResult_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_BASE_ID + 4,
@@ -129,7 +129,7 @@ impl<Manager> UserStats<Manager> {
                 details.as_ptr(),
                 details.len() as _,
             );
-            register_call_result::<sys::LeaderboardScoreUploaded_t, _, _>(
+            register_call_result::<sys::LeaderboardScoreUploaded_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_BASE_ID + 6,
@@ -184,7 +184,7 @@ impl<Manager> UserStats<Manager> {
                 end as _,
             );
             let user_stats = self.user_stats as isize;
-            register_call_result::<sys::LeaderboardScoresDownloaded_t, _, _>(
+            register_call_result::<sys::LeaderboardScoresDownloaded_t, _>(
                 &self.inner,
                 api_call,
                 CALLBACK_BASE_ID + 5,
@@ -315,7 +315,7 @@ impl<Manager> UserStats<Manager> {
         unsafe {
             let api_call =
                 sys::SteamAPI_ISteamUserStats_RequestGlobalAchievementPercentages(self.user_stats);
-            register_call_result::<sys::GlobalAchievementPercentagesReady_t, _, _>(
+            register_call_result::<sys::GlobalAchievementPercentagesReady_t, _>(
                 &self.inner,
                 api_call,
                 // `CALLBACK_BASE_ID + <number>`: <number> is found in Steamworks `isteamuserstats.h` header file
@@ -467,7 +467,7 @@ impl<Manager> UserStats<Manager> {
     /// and a successful [`UserStatsReceived`](./struct.UserStatsReceived.html) callback processed.
     #[inline]
     #[must_use]
-    pub fn achievement(&self, name: &str) -> stats::AchievementHelper<'_, Manager> {
+    pub fn achievement(&self, name: &str) -> stats::AchievementHelper<'_> {
         stats::AchievementHelper {
             name: CString::new(name).unwrap(),
             parent: self,

--- a/src/user_stats/stats.rs
+++ b/src/user_stats/stats.rs
@@ -16,12 +16,12 @@ use super::*;
 /// client.user_stats().achievement("WIN_THE_GAME").set()?;
 /// # Err(())
 /// ```
-pub struct AchievementHelper<'parent, M> {
+pub struct AchievementHelper<'parent> {
     pub(crate) name: CString,
-    pub(crate) parent: &'parent UserStats<M>,
+    pub(crate) parent: &'parent UserStats,
 }
 
-impl<M> AchievementHelper<'_, M> {
+impl AchievementHelper<'_> {
     /// Gets the unlock status of the Achievement.
     ///
     /// This call only modifies Steam's in-memory state so it is quite cheap. To send the unlock

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,9 +7,9 @@ use std::process::abort;
 use std::sync::RwLock;
 
 /// Access to the steam utils interface
-pub struct Utils<Manager> {
+pub struct Utils {
     pub(crate) utils: *mut sys::ISteamUtils,
-    pub(crate) _inner: Arc<Inner<Manager>>,
+    pub(crate) _inner: Arc<Inner>,
 }
 
 #[derive(Clone, Debug)]
@@ -136,7 +136,7 @@ unsafe extern "C" fn c_warning_callback(level: i32, msg: *const c_char) {
     }
 }
 
-impl<Manager> Utils<Manager> {
+impl Utils {
     /// Returns the app ID of the current process
     pub fn app_id(&self) -> AppId {
         unsafe { AppId(sys::SteamAPI_ISteamUtils_GetAppID(self.utils)) }


### PR DESCRIPTION
The `Manager` generic type param is prolific, it's everywhere in the codebase, but it really only comes down to only a single, non-performance sensitive call in `run_callbacks`, which is more of an implementation detail than anything else, but is surfaced on the consumer facing API. This makes the code harder to read, maintain, and consume.

This PR...

 *  Makes the Manager trait and types all private, object-safe, and a safe trait.
 *  Removes the generics on all of the types that really didn't need them.
 * Made the Manager field on the inner state a trait object instead, calling it over a static dispatch on the type in `run_callbacks`.
 * Moves some of the `unsafe impl`s for Send/Sync on top level types to lower level ones where appropriate. This is done to rely more on Send/Sync composition and ensure the non-FFI parts of this crate still remain safe.

This is a fairly major breaking change impacting almost all types in the crate.