### PR TITLE
feat(gameserver): proper game server support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ members = [
     "./steamworks-sys",
     "examples/chat-example",
     "examples/workshop",
-    "examples/lobby", "examples/networking-messages",
+    "examples/lobby",
+    "examples/networking-messages",
+    "examples/game-server",
 ]
 
 [dependencies]

--- a/examples/game-server/Cargo.toml
+++ b/examples/game-server/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "game-server"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+steamworks = { path = "../../" }

--- a/examples/game-server/src/main.rs
+++ b/examples/game-server/src/main.rs
@@ -1,0 +1,85 @@
+use std::net::{SocketAddrV4};
+use std::str::FromStr;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+use steamworks::{ServerMode};
+use steamworks::CallbackResult::{P2PSessionRequest, SteamServersConnected, GSClientApprove, GSClientDeny, GSClientKick, GSClientGroupStatus};
+
+const BUFFER_SIZE: usize = 1500;
+fn main() {
+    let bind_address = SocketAddrV4::from_str("0.0.0.0:54321")
+        .expect("Could not parse bind address");
+
+    // Client::init is not required with Server::Init as long as you set the app id via steam_appid.txt or env var
+    unsafe { std::env::set_var("SteamAppId", "480"); }
+    let (server, _) = steamworks::Server::init(
+        *bind_address.ip(), // in reality, this should be the external ip of the server
+        bind_address.port()-1,
+        bind_address.port(), // For some games, this port is actually the "main" port (and the game_port is unused)
+        ServerMode::AuthenticationAndSecure,
+        "123456",
+    ).expect("Could not register server with Steam Master server list");
+
+    server.set_server_name("Rusty Server");
+    server.set_dedicated_server(true);
+    server.set_max_players(10);
+
+    server.enable_heartbeats(true);
+    server.log_on_anonymous();
+
+    println!("{:?}", server.steam_id());
+
+    let networking = server.networking();
+    let networking_messages = server.networking_messages();
+
+    networking_messages.session_request_callback(|req| {
+        println!("Session request event");
+        req.accept();
+    });
+
+    let mut buffer = vec![0; BUFFER_SIZE];
+
+    loop {
+        let start = Instant::now();
+
+        server.process_callbacks(|event| {
+            match event {
+                SteamServersConnected(..) => {
+                    println!("Steam Servers Connected");
+                },
+                P2PSessionRequest(request) => {
+                    println!("Received a new Server P2P session request for {:?}", request.remote);
+                    networking.accept_p2p_session(request.remote);
+                },
+                GSClientApprove(info) => {
+                    println!("GSClientApprove {:?}", info);
+                },
+                GSClientDeny(denial) => {
+                    println!("GSClientDeny {:?}", denial);
+                },
+                GSClientKick(kick) => {
+                    println!("GSClientKick {:?}", kick);
+                },
+                GSClientGroupStatus(status) => {
+                    println!("GSClientGroupStatus {:?}", status);
+                },
+                _ => {
+                    println!("Unhandled event");
+                }
+            }
+        });
+
+        let size = networking.is_p2p_packet_available_on_channel(0);
+        if (size.is_some()) {
+            let (sender, size) = networking.read_p2p_packet_from_channel(&mut buffer, 2).expect("Could not read P2P packet");
+            println!("recv from: {:?}, size: {:?}, data: {:X?}", sender, size, &buffer);
+        }
+
+        let difference = Duration::from_secs_f32(1f32/60f32).checked_sub(start.elapsed());
+        if (difference != None) {
+            sleep(difference.unwrap());
+        } else {
+            println!("Event loop lagging!")
+        }
+    }
+}

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -30,6 +30,10 @@ pub enum CallbackResult {
     UserStatsReceived(UserStatsReceived),
     UserStatsStored(UserStatsStored),
     ValidateAuthTicketResponse(ValidateAuthTicketResponse),
+    GSClientApprove(GSClientApprove),
+    GSClientDeny(GSClientDeny),
+    GSClientKick(GSClientKick),
+    GSClientGroupStatus(GSClientGroupStatus),
 }
 
 impl CallbackResult {
@@ -89,6 +93,12 @@ impl CallbackResult {
             UserStatsStored::ID => Self::UserStatsStored(UserStatsStored::from_raw(data)),
             ValidateAuthTicketResponse::ID => {
                 Self::ValidateAuthTicketResponse(ValidateAuthTicketResponse::from_raw(data))
+            },
+            GSClientApprove::ID => Self::GSClientApprove(GSClientApprove::from_raw(data)),
+            GSClientDeny::ID => Self::GSClientDeny(GSClientDeny::from_raw(data)),
+            GSClientKick::ID => Self::GSClientKick(GSClientKick::from_raw(data)),
+            GSClientGroupStatus::ID => {
+                Self::GSClientGroupStatus(GSClientGroupStatus::from_raw(data))
             }
             _ => return None,
         })

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -35,16 +35,16 @@ impl Networking {
     /// Accepts incoming packets from the given user
     ///
     /// Should only be called in response to a `P2PSessionRequest`.
-    pub fn accept_p2p_session(&self, user: SteamId) {
+    pub fn accept_p2p_session(&self, user: SteamId) -> bool {
         unsafe {
-            sys::SteamAPI_ISteamNetworking_AcceptP2PSessionWithUser(self.net, user.0);
+            sys::SteamAPI_ISteamNetworking_AcceptP2PSessionWithUser(self.net, user.0)
         }
     }
 
     /// Closes the p2p connection between the given user
-    pub fn close_p2p_session(&self, user: SteamId) {
+    pub fn close_p2p_session(&self, user: SteamId) -> bool {
         unsafe {
-            sys::SteamAPI_ISteamNetworking_CloseP2PSessionWithUser(self.net, user.0);
+            sys::SteamAPI_ISteamNetworking_CloseP2PSessionWithUser(self.net, user.0)
         }
     }
 


### PR DESCRIPTION
This is my first time writing Rust, so please excuse any beginner mistakes. I ran into some limitations with the Server implementation while writing my own game server, and felt it was easy enough to upstream my desired functionality. I've added an example which illustrates the additions I've made (if you have an appropriate client).

### TLDR:

Server::init can now run without a separate Client::init, and also contains its own game-server-specific interface variants.

Also implemented the process_callbacks method on Server instances, so they can have a simpler interface. Added a few server-specific callbacks into the process_callbacks method.

Client interfaces such as client.remote_play(), client.remote_storage(), etc will still panic if called from Server classes.