### PR TITLE
Split the Mutex on Callbacks

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -71,7 +71,6 @@ impl CallbackResult {
                 Self::GameRichPresenceJoinRequested(GameRichPresenceJoinRequested::from_raw(data))
             }
             LobbyChatMsg::ID => Self::LobbyChatMsg(LobbyChatMsg::from_raw(data)),
-            LobbyChatUpdate::ID => Self::LobbyChatUpdate(LobbyChatUpdate::from_raw(data)),
             LobbyDataUpdate::ID => Self::LobbyDataUpdate(LobbyDataUpdate::from_raw(data)),
             MicroTxnAuthorizationResponse::ID => {
                 Self::MicroTxnAuthorizationResponse(MicroTxnAuthorizationResponse::from_raw(data))

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -129,9 +129,9 @@ pub struct CallbackHandle {
 impl Drop for CallbackHandle {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.upgrade() {
-            match inner.callbacks.lock() {
+            match inner.callbacks.callbacks.lock() {
                 Ok(mut cb) => {
-                    cb.callbacks.remove(&self.id);
+                    cb.remove(&self.id);
                 }
                 Err(err) => {
                     eprintln!("error while dropping callback: {:?}", err);
@@ -147,8 +147,7 @@ where
     F: FnMut(C) + Send + 'static,
 {
     {
-        let mut callbacks = inner.callbacks.lock().unwrap();
-        callbacks.callbacks.insert(
+        inner.callbacks.callbacks.lock().unwrap().insert(
             C::ID,
             Box::new(move |param| {
                 let param = C::from_raw(param);
@@ -165,13 +164,11 @@ where
 pub(crate) unsafe fn register_call_result<C, F>(
     inner: &Arc<Inner>,
     api_call: sys::SteamAPICall_t,
-    _callback_id: i32,
     f: F,
 ) where
     F: for<'a> FnOnce(&'a C, bool) + 'static + Send,
 {
-    let mut callbacks = inner.callbacks.lock().unwrap();
-    callbacks.call_results.insert(
+    inner.callbacks.call_results.lock().unwrap().insert(
         api_call,
         Box::new(move |param, failed| f(&*(param as *const C), failed)),
     );

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -1,8 +1,6 @@
 use super::*;
 use std::net::Ipv4Addr;
 
-const CALLBACK_BASE_ID: i32 = 300;
-
 bitflags! {
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[repr(C)]
@@ -233,7 +231,7 @@ pub struct PersonaStateChange {
 }
 
 unsafe impl Callback for PersonaStateChange {
-    const ID: i32 = CALLBACK_BASE_ID + 4;
+    const ID: i32 = sys::PersonaStateChange_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::PersonaStateChange_t);
@@ -251,7 +249,7 @@ pub struct GameOverlayActivated {
 }
 
 unsafe impl Callback for GameOverlayActivated {
-    const ID: i32 = CALLBACK_BASE_ID + 31;
+    const ID: i32 = sys::GameOverlayActivated_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::GameOverlayActivated_t);
@@ -269,7 +267,7 @@ pub struct GameLobbyJoinRequested {
 }
 
 unsafe impl Callback for GameLobbyJoinRequested {
-    const ID: i32 = CALLBACK_BASE_ID + 33;
+    const ID: i32 = sys::GameLobbyJoinRequested_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::GameLobbyJoinRequested_t);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,13 +90,14 @@ impl Clone for Client {
 
 struct Inner {
     manager: Box<dyn Manager>,
-    callbacks: Mutex<Callbacks>,
+    callbacks: Callbacks,
     networking_sockets_data: Mutex<NetworkingSocketsData>,
 }
 
 struct Callbacks {
-    callbacks: HashMap<i32, Box<dyn FnMut(*mut c_void) + Send + 'static>>,
-    call_results: HashMap<sys::SteamAPICall_t, Box<dyn FnOnce(*mut c_void, bool) + Send + 'static>>,
+    callbacks: Mutex<HashMap<i32, Box<dyn FnMut(*mut c_void) + Send + 'static>>>,
+    call_results:
+        Mutex<HashMap<sys::SteamAPICall_t, Box<dyn FnOnce(*mut c_void, bool) + Send + 'static>>>,
 }
 
 struct NetworkingSocketsData {
@@ -169,10 +170,10 @@ impl Client {
             sys::SteamAPI_ManualDispatch_Init();
             let client = Arc::new(Inner {
                 manager: Box::new(ClientManager),
-                callbacks: Mutex::new(Callbacks {
-                    callbacks: HashMap::new(),
-                    call_results: HashMap::new(),
-                }),
+                callbacks: Callbacks {
+                    callbacks: Mutex::new(HashMap::new()),
+                    call_results: Mutex::new(HashMap::new()),
+                },
                 networking_sockets_data: Mutex::new(NetworkingSocketsData {
                     sockets: Default::default(),
                     independent_connections: Default::default(),
@@ -213,8 +214,9 @@ impl Client {
     /// This should be called frequently (e.g. once per a frame)
     /// in order to reduce the latency between recieving events.
     pub fn run_callbacks(&self) {
-        self.run_callbacks_raw(|callbacks, cb_discrim, data| {
-            if let Some(cb) = callbacks.callbacks.get_mut(&cb_discrim) {
+        self.run_callbacks_raw(|cb_discrim, data| {
+            let mut callbacks = self.inner.callbacks.callbacks.lock().unwrap();
+            if let Some(cb) = callbacks.get_mut(&cb_discrim) {
                 cb(data);
             }
         });
@@ -231,9 +233,12 @@ impl Client {
     /// This should be called frequently (e.g. once per a frame)
     /// in order to reduce the latency between recieving events.
     pub fn process_callbacks(&self, mut callback_handler: impl FnMut(CallbackResult)) {
-        self.run_callbacks_raw(|callbacks, cb_discrim, data| {
-            if let Some(cb) = callbacks.callbacks.get_mut(&cb_discrim) {
-                cb(data);
+        self.run_callbacks_raw(|cb_discrim, data| {
+            {
+                let mut callbacks = self.inner.callbacks.callbacks.lock().unwrap();
+                if let Some(cb) = callbacks.get_mut(&cb_discrim) {
+                    cb(data);
+                }
             }
             let cb_result = unsafe { CallbackResult::from_raw(cb_discrim, data) };
             if let Some(cb_result) = cb_result {
@@ -242,16 +247,12 @@ impl Client {
         });
     }
 
-    fn run_callbacks_raw(
-        &self,
-        mut callback_handler: impl FnMut(&mut Callbacks, i32, *mut c_void),
-    ) {
+    fn run_callbacks_raw(&self, mut callback_handler: impl FnMut(i32, *mut c_void)) {
         unsafe {
             let pipe = self.inner.manager.get_pipe();
             sys::SteamAPI_ManualDispatch_RunFrame(pipe);
             let mut callback = std::mem::zeroed();
             while sys::SteamAPI_ManualDispatch_GetNextCallback(pipe, &mut callback) {
-                let mut callbacks = self.inner.callbacks.lock().unwrap();
                 if callback.m_iCallback == sys::SteamAPICallCompleted_t_k_iCallback as i32 {
                     let apicall =
                         &mut *(callback.m_pubParam as *mut _ as *mut sys::SteamAPICallCompleted_t);
@@ -265,18 +266,15 @@ impl Client {
                         apicall.m_iCallback,
                         &mut failed,
                     ) {
+                        let mut call_results = self.inner.callbacks.call_results.lock().unwrap();
                         // The &{val} pattern here is to avoid taking a reference to a packed field
                         // Since the value here is Copy, we can just copy it and borrow the copy
-                        if let Some(cb) = callbacks.call_results.remove(&{ apicall.m_hAsyncCall }) {
+                        if let Some(cb) = call_results.remove(&{ apicall.m_hAsyncCall }) {
                             cb(apicall_result.as_mut_ptr() as *mut _, failed);
                         }
                     }
                 } else {
-                    callback_handler(
-                        &mut callbacks,
-                        callback.m_iCallback,
-                        callback.m_pubParam as *mut _,
-                    );
+                    callback_handler(callback.m_iCallback, callback.m_pubParam as *mut _);
                 }
                 sys::SteamAPI_ManualDispatch_FreeLastCallback(pipe);
             }

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -13,8 +13,6 @@ pub struct Matchmaking {
     pub(crate) inner: Arc<Inner>,
 }
 
-const CALLBACK_BASE_ID: i32 = 500;
-
 /// The visibility of a lobby
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -57,7 +55,6 @@ impl Matchmaking {
             register_call_result::<sys::LobbyMatchList_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_BASE_ID + 10,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -103,7 +100,6 @@ impl Matchmaking {
             register_call_result::<sys::LobbyCreated_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_BASE_ID + 13,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -127,7 +123,6 @@ impl Matchmaking {
             register_call_result::<sys::LobbyEnter_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_BASE_ID + 4,
                 move |v, io_error| {
                     cb(if io_error || v.m_EChatRoomEnterResponse != 1 {
                         Err(())

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -1101,7 +1101,7 @@ pub struct LobbyChatMsg {
 }
 
 unsafe impl Callback for LobbyChatMsg {
-    const ID: i32 = 507;
+    const ID: i32 = sys::LobbyChatUpdate_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::LobbyChatMsg_t);
@@ -1130,7 +1130,7 @@ pub struct LobbyChatUpdate {
 }
 
 unsafe impl Callback for LobbyChatUpdate {
-    const ID: i32 = 506;
+    const ID: i32 = sys::LobbyChatUpdate_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::LobbyChatUpdate_t);
@@ -1174,7 +1174,7 @@ pub struct LobbyCreated {
 }
 
 unsafe impl Callback for LobbyCreated {
-    const ID: i32 = 513;
+    const ID: i32 = sys::LobbyCreated_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::LobbyCreated_t);
@@ -1200,7 +1200,7 @@ pub struct LobbyDataUpdate {
 }
 
 unsafe impl Callback for LobbyDataUpdate {
-    const ID: i32 = 505;
+    const ID: i32 = sys::LobbyDataUpdate_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::LobbyDataUpdate_t);
@@ -1228,7 +1228,7 @@ pub struct LobbyEnter {
 }
 
 unsafe impl Callback for LobbyEnter {
-    const ID: i32 = 504;
+    const ID: i32 = sys::LobbyEnter_t_k_iCallback as _;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::LobbyEnter_t);

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -144,7 +144,7 @@ pub struct P2PSessionRequest {
 }
 
 unsafe impl Callback for P2PSessionRequest {
-    const ID: i32 = 1202;
+    const ID: i32 = sys::P2PSessionRequest_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::P2PSessionRequest_t);
@@ -162,7 +162,7 @@ pub struct P2PSessionConnectFail {
 }
 
 unsafe impl Callback for P2PSessionConnectFail {
-    const ID: i32 = 1203;
+    const ID: i32 = sys::P2PSessionConnectFail_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::P2PSessionConnectFail_t);

--- a/src/server.rs
+++ b/src/server.rs
@@ -133,10 +133,10 @@ impl Server {
             let server_raw = sys::SteamAPI_SteamGameServer_v015();
             let server = Arc::new(Inner {
                 manager: Box::new(ServerManager),
-                callbacks: Mutex::new(Callbacks {
-                    callbacks: HashMap::new(),
-                    call_results: HashMap::new(),
-                }),
+                callbacks: Callbacks {
+                    callbacks: Mutex::new(HashMap::new()),
+                    call_results: Mutex::new(HashMap::new()),
+                },
                 networking_sockets_data: Mutex::new(NetworkingSocketsData {
                     sockets: Default::default(),
                     independent_connections: Default::default(),

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -16,7 +16,6 @@ pub struct UGC {
 }
 
 const CALLBACK_BASE_ID: i32 = 3400;
-const CALLBACK_REMOTE_STORAGE_BASE_ID: i32 = 1300;
 
 // TODO: should come from sys, but I don't think its generated.
 #[allow(non_upper_case_globals)]
@@ -535,7 +534,6 @@ impl UGC {
             register_call_result::<sys::CreateItemResult_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_BASE_ID + 3,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -576,7 +574,6 @@ impl UGC {
             register_call_result::<sys::RemoteStorageSubscribePublishedFileResult_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_REMOTE_STORAGE_BASE_ID + 13,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -599,7 +596,6 @@ impl UGC {
             register_call_result::<sys::RemoteStorageUnsubscribePublishedFileResult_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_REMOTE_STORAGE_BASE_ID + 15,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -811,7 +807,6 @@ impl UGC {
             register_call_result::<sys::DownloadItemResult_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_REMOTE_STORAGE_BASE_ID + 17,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -1018,7 +1013,6 @@ impl UpdateHandle {
             register_call_result::<sys::SubmitItemUpdateResult_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_BASE_ID + 4,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -1440,7 +1434,6 @@ impl QueryHandle {
             register_call_result::<sys::SteamUGCQueryCompleted_t, _>(
                 &inner,
                 api_call,
-                CALLBACK_BASE_ID + 1,
                 move |v, io_error| {
                     let ugc = sys::SteamAPI_SteamUGC_v021();
                     if io_error {

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -15,8 +15,6 @@ pub struct UGC {
     pub(crate) inner: Arc<Inner>,
 }
 
-const CALLBACK_BASE_ID: i32 = 3400;
-
 // TODO: should come from sys, but I don't think its generated.
 #[allow(non_upper_case_globals)]
 const UGCQueryHandleInvalid: u64 = 0xffffffffffffffff;
@@ -492,7 +490,7 @@ pub struct DownloadItemResult {
 }
 
 unsafe impl Callback for DownloadItemResult {
-    const ID: i32 = CALLBACK_BASE_ID + 6;
+    const ID: i32 = sys::DownloadItemResult_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::DownloadItemResult_t);

--- a/src/user.rs
+++ b/src/user.rs
@@ -227,7 +227,7 @@ pub struct AuthSessionTicketResponse {
 }
 
 unsafe impl Callback for AuthSessionTicketResponse {
-    const ID: i32 = 163;
+    const ID: i32 = sys::GetAuthSessionTicketResponse_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::GetAuthSessionTicketResponse_t);
@@ -276,7 +276,7 @@ pub struct TicketForWebApiResponse {
 }
 
 unsafe impl Callback for TicketForWebApiResponse {
-    const ID: i32 = 168;
+    const ID: i32 = sys::GetTicketForWebApiResponse_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         println!("From raw: {:?}", raw);
@@ -309,7 +309,7 @@ pub struct ValidateAuthTicketResponse {
 }
 
 unsafe impl Callback for ValidateAuthTicketResponse {
-    const ID: i32 = 143;
+    const ID: i32 = sys::ValidateAuthTicketResponse_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::ValidateAuthTicketResponse_t);
@@ -361,7 +361,7 @@ pub struct MicroTxnAuthorizationResponse {
 }
 
 unsafe impl Callback for MicroTxnAuthorizationResponse {
-    const ID: i32 = 152;
+    const ID: i32 = sys::MicroTxnAuthorizationResponse_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::MicroTxnAuthorizationResponse_t);
@@ -379,7 +379,7 @@ unsafe impl Callback for MicroTxnAuthorizationResponse {
 pub struct SteamServersConnected;
 
 unsafe impl Callback for SteamServersConnected {
-    const ID: i32 = 101;
+    const ID: i32 = sys::SteamServersConnected_t_k_iCallback as i32;
 
     unsafe fn from_raw(_: *mut c_void) -> Self {
         SteamServersConnected
@@ -395,7 +395,7 @@ pub struct SteamServersDisconnected {
 }
 
 unsafe impl Callback for SteamServersDisconnected {
-    const ID: i32 = 103;
+    const ID: i32 = sys::SteamServersDisconnected_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::SteamServersDisconnected_t);
@@ -416,7 +416,7 @@ pub struct SteamServerConnectFailure {
 }
 
 unsafe impl Callback for SteamServerConnectFailure {
-    const ID: i32 = 102;
+    const ID: i32 = sys::SteamServerConnectFailure_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::SteamServerConnectFailure_t);

--- a/src/user_stats.rs
+++ b/src/user_stats.rs
@@ -28,7 +28,6 @@ impl UserStats {
             register_call_result::<sys::LeaderboardFindResult_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_BASE_ID + 4,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -86,7 +85,6 @@ impl UserStats {
             register_call_result::<sys::LeaderboardFindResult_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_BASE_ID + 4,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -132,7 +130,6 @@ impl UserStats {
             register_call_result::<sys::LeaderboardScoreUploaded_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_BASE_ID + 6,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -187,7 +184,6 @@ impl UserStats {
             register_call_result::<sys::LeaderboardScoresDownloaded_t, _>(
                 &self.inner,
                 api_call,
-                CALLBACK_BASE_ID + 5,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)
@@ -311,9 +307,6 @@ impl UserStats {
             register_call_result::<sys::GlobalAchievementPercentagesReady_t, _>(
                 &self.inner,
                 api_call,
-                // `CALLBACK_BASE_ID + <number>`: <number> is found in Steamworks `isteamuserstats.h` header file
-                // (Under `struct GlobalAchievementPercentagesReady_t {...};` in this case)
-                CALLBACK_BASE_ID + 10,
                 move |v, io_error| {
                     cb(if io_error {
                         Err(SteamError::IOFailure)

--- a/src/user_stats.rs
+++ b/src/user_stats.rs
@@ -12,8 +12,6 @@ pub struct UserStats {
     pub(crate) inner: Arc<Inner>,
 }
 
-const CALLBACK_BASE_ID: i32 = 1100;
-
 impl UserStats {
     pub fn find_leaderboard<F>(&self, name: &str, cb: F)
     where

--- a/src/user_stats/stat_callback.rs
+++ b/src/user_stats/stat_callback.rs
@@ -22,7 +22,7 @@ pub struct UserStatsReceived {
 }
 
 unsafe impl Callback for UserStatsReceived {
-    const ID: i32 = CALLBACK_BASE_ID + 1;
+    const ID: i32 = sys::UserStatsReceived_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::UserStatsReceived_t);
@@ -57,7 +57,7 @@ pub struct UserStatsStored {
 }
 
 unsafe impl Callback for UserStatsStored {
-    const ID: i32 = CALLBACK_BASE_ID + 2;
+    const ID: i32 = sys::UserStatsStored_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::UserStatsStored_t);
@@ -95,7 +95,7 @@ pub struct UserAchievementStored {
 }
 
 unsafe impl Callback for UserAchievementStored {
-    const ID: i32 = CALLBACK_BASE_ID + 3;
+    const ID: i32 = sys::UserAchievementStored_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::UserAchievementStored_t);
@@ -128,7 +128,7 @@ pub struct UserAchievementIconFetched {
 }
 
 unsafe impl Callback for UserAchievementIconFetched {
-    const ID: i32 = CALLBACK_BASE_ID + 9;
+    const ID: i32 = sys::UserAchievementIconFetched_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::UserAchievementIconFetched_t);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,7 +18,7 @@ pub struct GamepadTextInputDismissed {
 }
 
 unsafe impl Callback for GamepadTextInputDismissed {
-    const ID: i32 = 714;
+    const ID: i32 = sys::GamepadTextInputDismissed_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
         let val = &mut *(raw as *mut sys::GamepadTextInputDismissed_t);
@@ -32,7 +32,7 @@ unsafe impl Callback for GamepadTextInputDismissed {
 pub struct FloatingGamepadTextInputDismissed;
 
 unsafe impl Callback for FloatingGamepadTextInputDismissed {
-    const ID: i32 = 738;
+    const ID: i32 = sys::FloatingGamepadTextInputDismissed_t_k_iCallback as i32;
 
     unsafe fn from_raw(_: *mut c_void) -> Self {
         FloatingGamepadTextInputDismissed


### PR DESCRIPTION
This partially addresses #253 by splitting the Mutex on Callbacks between the callbacks and the call results, which should resolve the deadlocks seen with #253.

As a separate cleanup, the unused parameter on `register_call_result` was removed.