### PR TITLE
Use unaligned reads to read callbacks and call results to avoid undefined behavior

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -173,6 +173,9 @@ pub(crate) unsafe fn register_call_result<C, F>(
     let mut callbacks = inner.callbacks.lock().unwrap();
     callbacks.call_results.insert(
         api_call,
-        Box::new(move |param, failed| f(&*(param as *const C), failed)),
+        Box::new(move |param, failed| {
+            let value = param.cast::<C>().read_unaligned();
+            f(&value, failed)
+        }),
     );
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,10 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::sys;
-use std::{
-    convert::TryFrom,
-    ffi::{c_char, CStr},
-};
+use std::{convert::TryFrom, ffi::CStr};
 
 /// Covers errors that can be returned by the steamworks API
 ///
@@ -756,7 +753,7 @@ impl SteamAPIInitError {
         message: sys::SteamErrMsg,
     ) -> Self {
         let err_string = unsafe {
-            let cstr = CStr::from_ptr(message.as_ptr() as *const c_char);
+            let cstr = CStr::from_ptr(message.as_ptr());
             cstr.to_string_lossy().to_owned().into_owned()
         };
 

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -125,10 +125,7 @@ impl Friends {
     pub fn activate_game_overlay(&self, dialog: &str) {
         let dialog = CString::new(dialog).unwrap();
         unsafe {
-            sys::SteamAPI_ISteamFriends_ActivateGameOverlay(
-                self.friends,
-                dialog.as_ptr() as *const _,
-            );
+            sys::SteamAPI_ISteamFriends_ActivateGameOverlay(self.friends, dialog.as_ptr());
         }
     }
 
@@ -138,7 +135,7 @@ impl Friends {
             let url = CString::new(url).unwrap();
             sys::SteamAPI_ISteamFriends_ActivateGameOverlayToWebPage(
                 self.friends,
-                url.as_ptr() as *const _,
+                url.as_ptr(),
                 sys::EActivateGameOverlayToWebPageMode::k_EActivateGameOverlayToWebPageMode_Default,
             );
         }
@@ -172,7 +169,7 @@ impl Friends {
         unsafe {
             sys::SteamAPI_ISteamFriends_ActivateGameOverlayToUser(
                 self.friends,
-                dialog.as_ptr() as *const _,
+                dialog.as_ptr(),
                 user.0,
             );
         }
@@ -194,8 +191,8 @@ impl Friends {
             let value = CString::new(value.unwrap_or_default()).unwrap();
             sys::SteamAPI_ISteamFriends_SetRichPresence(
                 self.friends,
-                key.as_ptr() as *const _,
-                value.as_ptr() as *const _,
+                key.as_ptr(),
+                value.as_ptr(),
             )
         }
     }
@@ -482,7 +479,7 @@ impl Friend {
             sys::SteamAPI_ISteamFriends_InviteUserToGame(
                 self.friends,
                 self.id.0,
-                connect_string.as_ptr() as *const _,
+                connect_string.as_ptr(),
             );
         }
     }

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -236,7 +236,7 @@ unsafe impl Callback for PersonaStateChange {
     const ID: i32 = CALLBACK_BASE_ID + 4;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::PersonaStateChange_t);
+        let val = raw.cast::<sys::PersonaStateChange_t>().read_unaligned();
         PersonaStateChange {
             steam_id: SteamId(val.m_ulSteamID),
             flags: PersonaChange::from_bits_truncate(val.m_nChangeFlags as i32),
@@ -254,7 +254,7 @@ unsafe impl Callback for GameOverlayActivated {
     const ID: i32 = CALLBACK_BASE_ID + 31;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::GameOverlayActivated_t);
+        let val = raw.cast::<sys::GameOverlayActivated_t>().read_unaligned();
         Self {
             active: val.m_bActive == 1,
         }
@@ -272,7 +272,7 @@ unsafe impl Callback for GameLobbyJoinRequested {
     const ID: i32 = CALLBACK_BASE_ID + 33;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::GameLobbyJoinRequested_t);
+        let val = raw.cast::<sys::GameLobbyJoinRequested_t>().read_unaligned();
         GameLobbyJoinRequested {
             lobby_steam_id: LobbyId(val.m_steamIDLobby.m_steamid.m_unAll64Bits),
             friend_steam_id: SteamId(val.m_steamIDFriend.m_steamid.m_unAll64Bits),
@@ -295,7 +295,9 @@ unsafe impl Callback for GameRichPresenceJoinRequested {
     const ID: i32 = sys::GameRichPresenceJoinRequested_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::GameRichPresenceJoinRequested_t);
+        let val = raw
+            .cast::<sys::GameRichPresenceJoinRequested_t>()
+            .read_unaligned();
         // Convert from &[i8] to &[u8] because c_char in C is signed.
         // Technically, this C string does not have to be UTF-8, but I think for all realistic uses it will be.
         let as_bytes = val.m_rgchConnect.map(|c| c as u8);

--- a/src/friends.rs
+++ b/src/friends.rs
@@ -189,11 +189,7 @@ impl Friends {
             // Unwraps are infallible because Rust strs cannot contain null bytes
             let key = CString::new(key).unwrap();
             let value = CString::new(value.unwrap_or_default()).unwrap();
-            sys::SteamAPI_ISteamFriends_SetRichPresence(
-                self.friends,
-                key.as_ptr(),
-                value.as_ptr(),
-            )
+            sys::SteamAPI_ISteamFriends_SetRichPresence(self.friends, key.as_ptr(), value.as_ptr())
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,17 +250,20 @@ impl Client {
             let pipe = self.inner.manager.get_pipe();
             sys::SteamAPI_ManualDispatch_RunFrame(pipe);
             let mut callback = std::mem::zeroed();
+            let mut apicall_result = Vec::new();
             while sys::SteamAPI_ManualDispatch_GetNextCallback(pipe, &mut callback) {
                 let mut callbacks = self.inner.callbacks.lock().unwrap();
                 if callback.m_iCallback == sys::SteamAPICallCompleted_t_k_iCallback as i32 {
-                    let apicall =
-                        &mut *(callback.m_pubParam as *mut _ as *mut sys::SteamAPICallCompleted_t);
-                    let mut apicall_result = vec![0; apicall.m_cubParam as usize];
+                    let apicall = callback
+                        .m_pubParam
+                        .cast::<sys::SteamAPICallCompleted_t>()
+                        .read_unaligned();
+                    apicall_result.resize(apicall.m_cubParam as usize, 0u8);
                     let mut failed = false;
                     if sys::SteamAPI_ManualDispatch_GetAPICallResult(
                         pipe,
                         apicall.m_hAsyncCall,
-                        apicall_result.as_mut_ptr() as *mut _,
+                        apicall_result.as_mut_ptr().cast(),
                         apicall.m_cubParam as _,
                         apicall.m_iCallback,
                         &mut failed,
@@ -268,14 +271,14 @@ impl Client {
                         // The &{val} pattern here is to avoid taking a reference to a packed field
                         // Since the value here is Copy, we can just copy it and borrow the copy
                         if let Some(cb) = callbacks.call_results.remove(&{ apicall.m_hAsyncCall }) {
-                            cb(apicall_result.as_mut_ptr() as *mut _, failed);
+                            cb(apicall_result.as_mut_ptr().cast(), failed);
                         }
                     }
                 } else {
                     callback_handler(
                         &mut callbacks,
                         callback.m_iCallback,
-                        callback.m_pubParam as *mut _,
+                        callback.m_pubParam.cast(),
                     );
                 }
                 sys::SteamAPI_ManualDispatch_FreeLastCallback(pipe);

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -342,7 +342,7 @@ impl Matchmaking {
             steamworks_sys::SteamAPI_ISteamMatchmaking_SendLobbyChatMsg(
                 self.mm,
                 lobby.0,
-                msg.as_ptr() as *const c_void,
+                msg.as_ptr().cast(),
                 msg.len() as i32,
             )
         } {
@@ -377,7 +377,7 @@ impl Matchmaking {
                 lobby.0,
                 chat_id,
                 &mut steam_user,
-                buffer.as_mut_ptr() as *mut _,
+                buffer.as_mut_ptr().cast(),
                 buffer.len() as _,
                 &mut chat_type,
             );

--- a/src/matchmaking.rs
+++ b/src/matchmaking.rs
@@ -1109,7 +1109,7 @@ unsafe impl Callback for LobbyChatMsg {
     const ID: i32 = 507;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::LobbyChatMsg_t);
+        let val = raw.cast::<sys::LobbyChatMsg_t>().read_unaligned();
 
         LobbyChatMsg {
             lobby: LobbyId(val.m_ulSteamIDLobby),
@@ -1138,7 +1138,7 @@ unsafe impl Callback for LobbyChatUpdate {
     const ID: i32 = 506;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::LobbyChatUpdate_t);
+        let val = raw.cast::<sys::LobbyChatUpdate_t>().read_unaligned();
 
         LobbyChatUpdate {
             lobby: LobbyId(val.m_ulSteamIDLobby),
@@ -1182,7 +1182,7 @@ unsafe impl Callback for LobbyCreated {
     const ID: i32 = 513;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::LobbyCreated_t);
+        let val = raw.cast::<sys::LobbyCreated_t>().read_unaligned();
 
         LobbyCreated {
             result: val.m_eResult as u32,
@@ -1208,7 +1208,7 @@ unsafe impl Callback for LobbyDataUpdate {
     const ID: i32 = 505;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::LobbyDataUpdate_t);
+        let val = raw.cast::<sys::LobbyDataUpdate_t>().read_unaligned();
 
         LobbyDataUpdate {
             lobby: LobbyId(val.m_ulSteamIDLobby),
@@ -1236,7 +1236,7 @@ unsafe impl Callback for LobbyEnter {
     const ID: i32 = 504;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::LobbyEnter_t);
+        let val = raw.cast::<sys::LobbyEnter_t>().read_unaligned();
 
         LobbyEnter {
             lobby: LobbyId(val.m_ulSteamIDLobby),

--- a/src/matchmaking_servers.rs
+++ b/src/matchmaking_servers.rs
@@ -153,7 +153,7 @@ macro_rules! gen_server_list_fn {
                 let handle = sys::$sys_method(
                     self.mms,
                     app_id,
-                    &mut filters.as_mut_ptr() as *mut *mut _,
+                    &mut filters.as_mut_ptr().cast(),
                     filters.len().try_into().unwrap(),
                     callbacks.cast(),
                 );

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -147,7 +147,7 @@ unsafe impl Callback for P2PSessionRequest {
     const ID: i32 = 1202;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::P2PSessionRequest_t);
+        let val = raw.cast::<sys::P2PSessionRequest_t>().read_unaligned();
         P2PSessionRequest {
             remote: SteamId(val.m_steamIDRemote.m_steamid.m_unAll64Bits),
         }
@@ -165,7 +165,7 @@ unsafe impl Callback for P2PSessionConnectFail {
     const ID: i32 = 1203;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::P2PSessionConnectFail_t);
+        let val = raw.cast::<sys::P2PSessionConnectFail_t>().read_unaligned();
         P2PSessionConnectFail {
             remote: SteamId(val.m_steamIDRemote.m_steamid.m_unAll64Bits),
             error: val.m_eP2PSessionError,

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -72,7 +72,7 @@ impl Networking {
             sys::SteamAPI_ISteamNetworking_SendP2PPacket(
                 self.net,
                 remote.0,
-                data.as_ptr() as *const _,
+                data.as_ptr().cast(),
                 data.len() as u32,
                 send_type,
                 channel,
@@ -120,7 +120,7 @@ impl Networking {
             let mut remote = 0;
             if sys::SteamAPI_ISteamNetworking_ReadP2PPacket(
                 self.net,
-                buf.as_mut_ptr() as *mut _,
+                buf.as_mut_ptr().cast(),
                 buf.len() as _,
                 &mut size,
                 &mut remote as *mut _ as *mut _,

--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -303,7 +303,9 @@ unsafe impl Callback for NetworkingMessagesSessionRequest {
     const ID: i32 = sys::SteamNetworkingMessagesSessionRequest_t_k_iCallback as _;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let remote = *(raw as *mut sys::SteamNetworkingMessagesSessionRequest_t);
+        let remote = raw
+            .cast::<sys::SteamNetworkingMessagesSessionRequest_t>()
+            .read_unaligned();
         let remote = remote.m_identityRemote.into();
         Self { remote }
     }
@@ -317,7 +319,9 @@ unsafe impl Callback for NetworkingMessagesSessionFailed {
     const ID: i32 = sys::SteamNetworkingMessagesSessionFailed_t_k_iCallback as _;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let remote = *(raw as *mut sys::SteamNetworkingMessagesSessionFailed_t);
+        let remote = raw
+            .cast::<sys::SteamNetworkingMessagesSessionFailed_t>()
+            .read_unaligned();
         let remote = remote.m_info.into();
         Self { info: remote }
     }

--- a/src/networking_messages.rs
+++ b/src/networking_messages.rs
@@ -96,7 +96,7 @@ impl NetworkingMessages {
             sys::SteamAPI_ISteamNetworkingMessages_SendMessageToUser(
                 self.net,
                 user.as_ptr(),
-                data.as_ptr() as *const c_void,
+                data.as_ptr().cast(),
                 data.len() as u32,
                 send_type.bits(),
                 channel as i32,

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -2074,9 +2074,7 @@ impl SteamIpAddr {
     }
 
     pub fn get_ipv4(&self) -> Option<Ipv4Addr> {
-        let ip = unsafe {
-            sys::SteamAPI_SteamNetworkingIPAddr_GetIPv4(&self.inner as *const _ as *mut _)
-        };
+        let ip = unsafe { sys::SteamAPI_SteamNetworkingIPAddr_GetIPv4(self.as_ptr() as *mut _) };
         if ip == 0 {
             None
         } else {
@@ -2159,10 +2157,7 @@ impl Default for SteamIpAddr {
 impl PartialEq for SteamIpAddr {
     fn eq(&self, other: &Self) -> bool {
         unsafe {
-            sys::SteamAPI_SteamNetworkingIPAddr_IsEqualTo(
-                &self.inner as *const _ as *mut _,
-                &other.inner,
-            )
+            sys::SteamAPI_SteamNetworkingIPAddr_IsEqualTo(self.as_ptr() as *mut _, &other.inner)
         }
     }
 }

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1417,7 +1417,9 @@ unsafe impl Callback for NetConnectionStatusChanged {
     const ID: i32 = sys::SteamNetConnectionStatusChangedCallback_t_k_iCallback as _;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::SteamNetConnectionStatusChangedCallback_t);
+        let val = raw
+            .cast::<sys::SteamNetConnectionStatusChangedCallback_t>()
+            .read_unaligned();
 
         NetConnectionStatusChanged {
             connection: val.m_hConn,

--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -185,7 +185,9 @@ unsafe impl Callback for RelayNetworkStatusCallback {
     const ID: i32 = sys::SteamRelayNetworkStatus_t_k_iCallback as _;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let status = *(raw as *mut sys::SteamRelayNetworkStatus_t);
+        let status = raw
+            .cast::<sys::SteamRelayNetworkStatus_t>()
+            .read_unaligned();
         Self {
             status: status.into(),
         }

--- a/src/remote_play.rs
+++ b/src/remote_play.rs
@@ -163,7 +163,9 @@ unsafe impl Callback for RemotePlayConnected {
     const ID: i32 = sys::SteamRemotePlaySessionConnected_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::SteamRemotePlaySessionConnected_t);
+        let val = raw
+            .cast::<sys::SteamRemotePlaySessionConnected_t>()
+            .read_unaligned();
         RemotePlayConnected {
             session: RemotePlaySessionId::from_raw(val.m_unSessionID),
         }
@@ -182,7 +184,9 @@ unsafe impl Callback for RemotePlayDisconnected {
     const ID: i32 = sys::SteamRemotePlaySessionDisconnected_t_k_iCallback as i32;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::SteamRemotePlaySessionDisconnected_t);
+        let val = raw
+            .cast::<sys::SteamRemotePlaySessionDisconnected_t>()
+            .read_unaligned();
         RemotePlayDisconnected {
             session: RemotePlaySessionId::from_raw(val.m_unSessionID),
         }

--- a/src/remote_storage.rs
+++ b/src/remote_storage.rs
@@ -180,7 +180,7 @@ impl std::io::Write for SteamFileWriter {
             if sys::SteamAPI_ISteamRemoteStorage_FileWriteStreamWriteChunk(
                 self.file.rs,
                 self.handle,
-                buf.as_ptr() as *const _,
+                buf.as_ptr().cast(),
                 buf.len() as _,
             ) {
                 Ok(buf.len())
@@ -253,7 +253,7 @@ impl std::io::Read for SteamFileReader {
             sys::SteamAPI_ISteamRemoteStorage_FileReadAsyncComplete(
                 self.file.rs,
                 callback.m_hFileReadAsync,
-                buf.as_mut_ptr() as *mut _,
+                buf.as_mut_ptr().cast(),
                 callback.m_cubRead,
             );
 

--- a/src/screenshots.rs
+++ b/src/screenshots.rs
@@ -135,7 +135,7 @@ unsafe impl Callback for ScreenshotReady {
     const ID: i32 = sys::ScreenshotReady_t__bindgen_ty_1::k_iCallback as _;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let status = *(raw as *mut sys::ScreenshotReady_t);
+        let status = raw.cast::<sys::ScreenshotReady_t>().read_unaligned();
         let local_handle = match status.m_eResult {
             sys::EResult::k_EResultOK => Ok(status.m_hLocal),
             sys::EResult::k_EResultIOFailure => Err(ScreenshotReadyError::Fail),

--- a/src/server.rs
+++ b/src/server.rs
@@ -60,7 +60,7 @@ impl Server {
         ];
 
         let merged_versions: Vec<u8> = versions.into_iter().flatten().cloned().collect();
-        let merged_versions_ptr = merged_versions.as_ptr() as *const ::std::os::raw::c_char;
+        let merged_versions_ptr = merged_versions.as_ptr().cast::<::std::os::raw::c_char>();
 
         return unsafe {
             sys::SteamInternal_GameServer_Init_V2(
@@ -197,7 +197,7 @@ impl Server {
             let mut ticket_len = 0;
             let auth_ticket = sys::SteamAPI_ISteamGameServer_GetAuthSessionTicket(
                 self.server,
-                ticket.as_mut_ptr() as *mut _,
+                ticket.as_mut_ptr().cast(),
                 1024,
                 &mut ticket_len,
                 network_identity.as_ptr(),
@@ -234,7 +234,7 @@ impl Server {
         unsafe {
             let res = sys::SteamAPI_ISteamGameServer_BeginAuthSession(
                 self.server,
-                ticket.as_ptr() as *const _,
+                ticket.as_ptr().cast(),
                 ticket.len() as _,
                 user.0,
             );
@@ -279,7 +279,7 @@ impl Server {
     pub fn set_product(&self, product: &str) {
         let product = CString::new(product).unwrap();
         unsafe {
-            sys::SteamAPI_ISteamGameServer_SetProduct(self.server, product.as_ptr() as *const _);
+            sys::SteamAPI_ISteamGameServer_SetProduct(self.server, product.as_ptr());
         }
     }
 

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -496,7 +496,7 @@ unsafe impl Callback for DownloadItemResult {
     const ID: i32 = CALLBACK_BASE_ID + 6;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::DownloadItemResult_t);
+        let val = raw.cast::<sys::DownloadItemResult_t>().read_unaligned();
         DownloadItemResult {
             app_id: AppId(val.m_unAppID),
             published_file_id: PublishedFileId(val.m_nPublishedFileId),

--- a/src/ugc.rs
+++ b/src/ugc.rs
@@ -671,7 +671,7 @@ impl UGC {
                 &mut timestamp,
             ) {
                 Some(InstallInfo {
-                    folder: CStr::from_ptr(folder.as_ptr() as *const _)
+                    folder: CStr::from_ptr(folder.as_ptr())
                         .to_string_lossy()
                         .into_owned(),
                     size_on_disk,
@@ -1548,11 +1548,7 @@ impl<'a> QueryResults<'a> {
         };
 
         if ok {
-            Some(unsafe {
-                CStr::from_ptr(url.as_ptr() as *const _)
-                    .to_string_lossy()
-                    .into_owned()
-            })
+            Some(unsafe { CStr::from_ptr(url.as_ptr()).to_string_lossy().into_owned() })
         } else {
             None
         }
@@ -1730,10 +1726,8 @@ impl<'a> QueryResults<'a> {
         if ok {
             Some(unsafe {
                 (
-                    CStr::from_ptr(key.as_ptr() as *const _)
-                        .to_string_lossy()
-                        .into_owned(),
-                    CStr::from_ptr(value.as_ptr() as *const _)
+                    CStr::from_ptr(key.as_ptr()).to_string_lossy().into_owned(),
+                    CStr::from_ptr(value.as_ptr())
                         .to_string_lossy()
                         .into_owned(),
                 )
@@ -1760,7 +1754,7 @@ impl<'a> QueryResults<'a> {
         };
 
         if ok {
-            let metadata = unsafe { CStr::from_ptr(metadata.as_ptr() as *const _).to_bytes() };
+            let metadata = unsafe { CStr::from_ptr(metadata.as_ptr()).to_bytes() };
             if metadata.is_empty() {
                 None
             } else {

--- a/src/user.rs
+++ b/src/user.rs
@@ -51,7 +51,7 @@ impl User {
             let mut ticket_len = 0;
             let auth_ticket = sys::SteamAPI_ISteamUser_GetAuthSessionTicket(
                 self.user,
-                ticket.as_mut_ptr() as *mut _,
+                ticket.as_mut_ptr().cast(),
                 1024,
                 &mut ticket_len,
                 network_identity.as_ptr(),
@@ -88,7 +88,7 @@ impl User {
         unsafe {
             let res = sys::SteamAPI_ISteamUser_BeginAuthSession(
                 self.user,
-                ticket.as_ptr() as *const _,
+                ticket.as_ptr().cast(),
                 ticket.len() as _,
                 user.0,
             );
@@ -142,10 +142,8 @@ impl User {
     pub fn authentication_session_ticket_for_webapi(&self, identity: &str) -> AuthTicket {
         unsafe {
             let c_str = CString::new(identity).unwrap();
-            let c_world: *const ::std::os::raw::c_char =
-                c_str.as_ptr() as *const ::std::os::raw::c_char;
-
-            let auth_ticket = sys::SteamAPI_ISteamUser_GetAuthTicketForWebApi(self.user, c_world);
+            let auth_ticket =
+                sys::SteamAPI_ISteamUser_GetAuthTicketForWebApi(self.user, c_str.as_ptr());
 
             AuthTicket(auth_ticket)
         }

--- a/src/user.rs
+++ b/src/user.rs
@@ -230,7 +230,9 @@ unsafe impl Callback for AuthSessionTicketResponse {
     const ID: i32 = 163;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::GetAuthSessionTicketResponse_t);
+        let val = raw
+            .cast::<sys::GetAuthSessionTicketResponse_t>()
+            .read_unaligned();
         AuthSessionTicketResponse {
             ticket: AuthTicket(val.m_hAuthTicket),
             result: if val.m_eResult == sys::EResult::k_EResultOK {
@@ -279,9 +281,9 @@ unsafe impl Callback for TicketForWebApiResponse {
     const ID: i32 = 168;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        println!("From raw: {:?}", raw);
-
-        let val = &mut *(raw as *mut sys::GetTicketForWebApiResponse_t);
+        let val = raw
+            .cast::<sys::GetTicketForWebApiResponse_t>()
+            .read_unaligned();
         TicketForWebApiResponse {
             ticket_handle: AuthTicket(val.m_hAuthTicket),
             result: if val.m_eResult == sys::EResult::k_EResultOK {
@@ -312,7 +314,9 @@ unsafe impl Callback for ValidateAuthTicketResponse {
     const ID: i32 = 143;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::ValidateAuthTicketResponse_t);
+        let val = raw
+            .cast::<sys::ValidateAuthTicketResponse_t>()
+            .read_unaligned();
         ValidateAuthTicketResponse {
             steam_id: SteamId(val.m_SteamID.m_steamid.m_unAll64Bits),
             owner_steam_id: SteamId(val.m_OwnerSteamID.m_steamid.m_unAll64Bits),
@@ -364,7 +368,9 @@ unsafe impl Callback for MicroTxnAuthorizationResponse {
     const ID: i32 = 152;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::MicroTxnAuthorizationResponse_t);
+        let val = raw
+            .cast::<sys::MicroTxnAuthorizationResponse_t>()
+            .read_unaligned();
         MicroTxnAuthorizationResponse {
             app_id: val.m_unAppID.into(),
             order_id: val.m_ulOrderID.into(),
@@ -398,7 +404,9 @@ unsafe impl Callback for SteamServersDisconnected {
     const ID: i32 = 103;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::SteamServersDisconnected_t);
+        let val = raw
+            .cast::<sys::SteamServersDisconnected_t>()
+            .read_unaligned();
         SteamServersDisconnected {
             reason: val.m_eResult.into(),
         }
@@ -419,7 +427,9 @@ unsafe impl Callback for SteamServerConnectFailure {
     const ID: i32 = 102;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::SteamServerConnectFailure_t);
+        let val = raw
+            .cast::<sys::SteamServerConnectFailure_t>()
+            .read_unaligned();
         SteamServerConnectFailure {
             reason: val.m_eResult.into(),
             still_retrying: val.m_bStillRetrying,

--- a/src/user_stats.rs
+++ b/src/user_stats.rs
@@ -21,10 +21,8 @@ impl UserStats {
     {
         unsafe {
             let name = CString::new(name).unwrap();
-            let api_call = sys::SteamAPI_ISteamUserStats_FindLeaderboard(
-                self.user_stats,
-                name.as_ptr() as *const _,
-            );
+            let api_call =
+                sys::SteamAPI_ISteamUserStats_FindLeaderboard(self.user_stats, name.as_ptr());
             register_call_result::<sys::LeaderboardFindResult_t, _>(
                 &self.inner,
                 api_call,
@@ -79,7 +77,7 @@ impl UserStats {
 
             let api_call = sys::SteamAPI_ISteamUserStats_FindOrCreateLeaderboard(
                 self.user_stats,
-                name.as_ptr() as *const _,
+                name.as_ptr(),
                 sort_method,
                 display_type,
             );
@@ -365,11 +363,7 @@ impl UserStats {
 
         let mut value: i32 = 0;
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_GetStatInt32(
-                self.user_stats,
-                name.as_ptr() as *const _,
-                &mut value,
-            )
+            sys::SteamAPI_ISteamUserStats_GetStatInt32(self.user_stats, name.as_ptr(), &mut value)
         };
         if success {
             Ok(value)
@@ -391,11 +385,7 @@ impl UserStats {
         let name = CString::new(name).unwrap();
 
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_SetStatInt32(
-                self.user_stats,
-                name.as_ptr() as *const _,
-                stat,
-            )
+            sys::SteamAPI_ISteamUserStats_SetStatInt32(self.user_stats, name.as_ptr(), stat)
         };
         if success {
             Ok(())
@@ -415,11 +405,7 @@ impl UserStats {
 
         let mut value: f32 = 0.0;
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_GetStatFloat(
-                self.user_stats,
-                name.as_ptr() as *const _,
-                &mut value,
-            )
+            sys::SteamAPI_ISteamUserStats_GetStatFloat(self.user_stats, name.as_ptr(), &mut value)
         };
         if success {
             Ok(value)
@@ -441,11 +427,7 @@ impl UserStats {
         let name = CString::new(name).unwrap();
 
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_SetStatFloat(
-                self.user_stats,
-                name.as_ptr() as *const _,
-                stat,
-            )
+            sys::SteamAPI_ISteamUserStats_SetStatFloat(self.user_stats, name.as_ptr(), stat)
         };
         if success {
             Ok(())

--- a/src/user_stats/stat_callback.rs
+++ b/src/user_stats/stat_callback.rs
@@ -25,7 +25,7 @@ unsafe impl Callback for UserStatsReceived {
     const ID: i32 = CALLBACK_BASE_ID + 1;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::UserStatsReceived_t);
+        let val = raw.cast::<sys::UserStatsReceived_t>().read_unaligned();
         Self {
             steam_id: SteamId(val.m_steamIDUser.m_steamid.m_unAll64Bits),
             game_id: GameId(val.m_nGameID),
@@ -60,7 +60,7 @@ unsafe impl Callback for UserStatsStored {
     const ID: i32 = CALLBACK_BASE_ID + 2;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::UserStatsStored_t);
+        let val = raw.cast::<sys::UserStatsStored_t>().read_unaligned();
         Self {
             game_id: GameId(val.m_nGameID),
             result: match val.m_eResult {
@@ -98,7 +98,7 @@ unsafe impl Callback for UserAchievementStored {
     const ID: i32 = CALLBACK_BASE_ID + 3;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::UserAchievementStored_t);
+        let val = raw.cast::<sys::UserAchievementStored_t>().read_unaligned();
         let name = CStr::from_ptr(val.m_rgchAchievementName.as_ptr()).to_owned();
         Self {
             game_id: GameId(val.m_nGameID),
@@ -131,7 +131,9 @@ unsafe impl Callback for UserAchievementIconFetched {
     const ID: i32 = CALLBACK_BASE_ID + 9;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::UserAchievementIconFetched_t);
+        let val = raw
+            .cast::<sys::UserAchievementIconFetched_t>()
+            .read_unaligned();
         let name = CStr::from_ptr(val.m_rgchAchievementName.as_ptr()).to_owned();
         Self {
             game_id: GameId(val.m_nGameID.__bindgen_anon_1.m_ulGameID),

--- a/src/user_stats/stats.rs
+++ b/src/user_stats/stats.rs
@@ -35,8 +35,8 @@ impl AchievementHelper<'_> {
             let mut achieved = false;
             let success = sys::SteamAPI_ISteamUserStats_GetAchievement(
                 self.parent.user_stats,
-                self.name.as_ptr() as *const _,
-                &mut achieved as *mut _,
+                self.name.as_ptr(),
+                &mut achieved,
             );
             if success {
                 Ok(achieved)
@@ -56,10 +56,7 @@ impl AchievementHelper<'_> {
     /// [`UserStatsReceived`](../struct.UserStatsReceived.html).
     pub fn set(&self) -> Result<(), ()> {
         let success = unsafe {
-            sys::SteamAPI_ISteamUserStats_SetAchievement(
-                self.parent.user_stats,
-                self.name.as_ptr() as *const _,
-            )
+            sys::SteamAPI_ISteamUserStats_SetAchievement(self.parent.user_stats, self.name.as_ptr())
         };
         if success {
             Ok(())
@@ -80,7 +77,7 @@ impl AchievementHelper<'_> {
         let success = unsafe {
             sys::SteamAPI_ISteamUserStats_ClearAchievement(
                 self.parent.user_stats,
-                self.name.as_ptr() as *const _,
+                self.name.as_ptr(),
             )
         };
         if success {
@@ -122,8 +119,8 @@ impl AchievementHelper<'_> {
             let mut percent = 0.0;
             let success = sys::SteamAPI_ISteamUserStats_GetAchievementAchievedPercent(
                 self.parent.user_stats,
-                self.name.as_ptr() as *const _,
-                &mut percent as *mut _,
+                self.name.as_ptr(),
+                &mut percent,
             );
             if success {
                 Ok(percent)
@@ -168,12 +165,11 @@ impl AchievementHelper<'_> {
     pub fn get_achievement_display_attribute(&self, key: &str) -> Result<&str, ()> {
         unsafe {
             let key_c_str = CString::new(key).expect("Failed to create c_str from key parameter");
-            let ptr = key_c_str.as_ptr() as *const i8;
 
             let str = sys::SteamAPI_ISteamUserStats_GetAchievementDisplayAttribute(
                 self.parent.user_stats,
-                self.name.as_ptr() as *const _,
-                ptr,
+                self.name.as_ptr(),
+                key_c_str.as_ptr(),
             );
 
             let c_str = CStr::from_ptr(str);
@@ -203,7 +199,7 @@ impl AchievementHelper<'_> {
             let utils: *mut sys::ISteamUtils = sys::SteamAPI_SteamUtils_v010();
             let img = sys::SteamAPI_ISteamUserStats_GetAchievementIcon(
                 self.parent.user_stats,
-                self.name.as_ptr() as *const _,
+                self.name.as_ptr(),
             );
             if img == 0 {
                 return None;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,7 +21,9 @@ unsafe impl Callback for GamepadTextInputDismissed {
     const ID: i32 = 714;
 
     unsafe fn from_raw(raw: *mut c_void) -> Self {
-        let val = &mut *(raw as *mut sys::GamepadTextInputDismissed_t);
+        let val = raw
+            .cast::<sys::GamepadTextInputDismissed_t>()
+            .read_unaligned();
         GamepadTextInputDismissed {
             submitted_text_len: val.m_bSubmitted.then_some(val.m_unSubmittedText),
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -227,7 +227,7 @@ impl Utils {
 
             sys::SteamAPI_ISteamUtils_GetEnteredGamepadTextInput(
                 self.utils,
-                buf.as_mut_ptr() as *mut i8,
+                buf.as_mut_ptr().cast(),
                 len,
             )
             .then(|| String::from_utf8(buf).expect("Steamworks returned invalid UTF-8 string"))
@@ -328,7 +328,7 @@ impl SteamParamStringArray {
     pub(crate) fn as_raw(&mut self) -> sys::SteamParamStringArray_t {
         sys::SteamParamStringArray_t {
             m_nNumStrings: self.0.len() as i32,
-            m_ppStrings: self.0.as_mut_ptr() as *mut *const i8,
+            m_ppStrings: self.0.as_mut_ptr().cast(),
         }
     }
 }


### PR DESCRIPTION
When handling callbacks and call results, we're turning the provided pointers into references without validating that the pointer is aligned for the type, which [according to the reference](https://doc.rust-lang.org/std/ptr/index.html#pointer-to-reference-conversion) is an unsound use of ùnsafe`.

This PR uses [`ptr::read_unaligned`](https://doc.rust-lang.org/std/ptr/fn.read_unaligned.html) to avoid this issue. This could result in a bit of a performance regression, but avoids any undefined behavior regardless of what the Steam SDK does.

This PR also cleans up a lot of the unnecessary pointer casting.