### PR TITLE
Add ActivateGameOverlayInviteDialogConnectString

### DIFF
--- a/src/friends.rs
+++ b/src/friends.rs
@@ -180,6 +180,15 @@ impl Friends {
         }
     }
 
+    /// Opens up an invite dialog that will send Rich Presence connect string to friends
+    pub fn activate_invite_dialog_connect_string(&self, connect: &str) {
+        // Unwraps can only fail if string contains a nul byte
+        let connect = CString::new(connect).unwrap();
+        unsafe {
+            sys::SteamAPI_ISteamFriends_ActivateGameOverlayInviteDialogConnectString(self.friends, connect.as_ptr());
+        }
+    }
+
     /// Set rich presence for the user. Unsets the rich presence if `value` is None or empty.
     /// See [Steam API](https://partner.steamgames.com/doc/api/ISteamFriends#SetRichPresence)
     pub fn set_rich_presence(&self, key: &str, value: Option<&str>) -> bool {


### PR DESCRIPTION
It is not documented in the [ISteamFriends documentation](https://partner.steamgames.com/doc/api/isteamfriends) but a function `ActivateGameOverlayInviteDialogConnectString` exists akin to `ActivateGameOverlayInviteDialog`, except that instead of accepting a LobbyID, it takes a connect string as input for RichPresence.

This pull request implements that.

Note: I should mention that a few lines below the comment `// Unwraps are infallible because Rust strs cannot contain null bytes` is incorrect: see the [playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=9203ca727c18abc14ed68fdc7efd5601). Here I am only using safe rust, and rust accepts a null byte inside a String very well, either normally or through `from_utf8_lossy` which converts incorrect characters into the replacement character.

Because of this, the assumption that it will never panic because a String can not have nul bytes inside is incorrect. I don't know how you want to fix this, but I prefer to let you know.