### PR TITLE
Make DenyReason serializable

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -674,6 +674,7 @@ impl_callback!(cb: GSClientApprove_t => GSClientApprove {
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DenyReason {
     Invalid,
     InvalidVersion,


### PR DESCRIPTION
I'm trying to update [steamworks.js](https://github.com/ceifa/steamworks.js) to the latest version of this library, and I'm getting a bunch of compiler errors that basically boil down to:
```
error[E0277]: the trait bound `DenyReason: _::_serde::Deserialize<'_>` is not satisfied
   --> C:\Users\Jesper\Documents\repositories\steamworks-rs\src\server.rs:746:49
    |
746 | #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
    |                                                 ^^^^^^^^^^^ the trait `_::_serde::Deserialize<'_>` is not implemented for `DenyReason`
    |
    = note: for local types consider adding `#[derive(serde::Deserialize)]` to your `DenyReason` type
    = note: for types from other crates check whether the crate offers a `serde` feature flag
    = help: the following other types implement trait `_::_serde::Deserialize<'de>`:
              &'a Path
              &'a [u8]
              &'a str
              ()
              (T,)
              (T0, T1)
              (T0, T1, T2)
              (T0, T1, T2, T3)
            and 207 others
note: required by a bound in `_::_serde::__private::de::missing_field`
   --> C:\Users\Jesper\.cargo\registry\src\index.crates.io-6f17d22bba15001f\serde-1.0.204\src\private\de.rs:25:8
    |
23  | pub fn missing_field<'de, V, E>(field: &'static str) -> Result<V, E>
    |        ------------- required by a bound in this function
24  | where
25  |     V: Deserialize<'de>,
    |        ^^^^^^^^^^^^^^^^ required by this bound in `missing_field`
    = note: this error originates in the derive macro `Deserialize` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
```

I'm not very familiar with rust so I'm not entirely sure if this is the correct way to fix this or if something should be changed in steamworks.js instead, but adding this line seems to fix these errors.