### PR TITLE
Add NewUrlLaunchParameters callback

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -157,3 +157,12 @@ impl Apps {
         }
     }
 }
+
+/// Called after the user executes a steam url with command line or query parameters such as steam://run/<appid>//?param1=value1;param2=value2;param3=value3; while the game is already running.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct NewUrlLaunchParameters;
+
+impl_callback!(_cb: NewUrlLaunchParameters_t => NewUrlLaunchParameters {
+    Self
+});

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -48,6 +48,7 @@ pub enum CallbackResult {
     GSClientDeny(GSClientDeny),
     GSClientKick(GSClientKick),
     GSClientGroupStatus(GSClientGroupStatus),
+    NewUrlLaunchParameters(NewUrlLaunchParameters),
 }
 
 impl CallbackResult {
@@ -116,6 +117,9 @@ impl CallbackResult {
             GSClientKick::ID => Self::GSClientKick(GSClientKick::from_raw(data)),
             GSClientGroupStatus::ID => {
                 Self::GSClientGroupStatus(GSClientGroupStatus::from_raw(data))
+            }
+            NewUrlLaunchParameters::ID => {
+                Self::NewUrlLaunchParameters(NewUrlLaunchParameters::from_raw(data))
             }
             _ => return None,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,9 @@ pub use crate::user::*;
 pub use crate::user_stats::*;
 pub use crate::utils::*;
 
-mod app;
 #[macro_use]
 mod callback;
+mod app;
 mod error;
 mod friends;
 mod input;


### PR DESCRIPTION
I had to move the `#[macro_use] mod callback;` section above the `mod app;` in order for the `impl_callback!` macro to work. Other than that I essentially copied everything from the `SteamServersConnected`, as that was the only callback without any extra parameters just like this one.

I tested this locally using an [updated version of steamworks.js](https://github.com/ceifa/steamworks.js/pull/196) in an electron app, and everything seems to work.