### PR TITLE
Add launch_query_param

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -156,6 +156,21 @@ impl Apps {
             command_line.to_string_lossy().into_owned()
         }
     }
+
+    /// Gets the associated launch parameter if the game is run via steam://run/<appid>/?param1=value1;param2=value2;param3=value3 etc.
+    ///
+    /// Parameter names starting with the character '@' are reserved for internal use and will always return an empty string.
+    /// Parameter names starting with an underscore '_' are reserved for steam features -- they can be queried by the game, but it is advised that you don't use param names beginning with an underscore for your own features.
+    ///
+    /// See [Steam API](https://partner.steamgames.com/doc/api/ISteamApps#GetLaunchQueryParam)
+    pub fn launch_query_param(&self, key: &str) -> String {
+        let key = CString::new(key).unwrap();
+        unsafe {
+            let value = sys::SteamAPI_ISteamApps_GetLaunchQueryParam(self.apps, key.as_ptr());
+            let value = CStr::from_ptr(value);
+            value.to_string_lossy().into_owned()
+        }
+    }
 }
 
 /// Called after the user executes a steam url with command line or query parameters such as steam://run/<appid>//?param1=value1;param2=value2;param3=value3; while the game is already running.


### PR DESCRIPTION
At first I thought this would be kind of pointless because I expected `launch_command_line()` to already include parameters, but as it turns out, this is not the case.

So say you were to open `steam://run/<appid>//myPath/?param1=value1;param2=value2`, you can use:
- `launch_command_line()` to get `"myPath"`
- `launch_query_param("param1")` to get `"value1"`
- `launch_query_param("param2")` to get `"value2"`