### PR TITLE
NetworkingIdentity new impl and fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,10 @@ impl Client {
         }
     }
 
+    pub(crate) fn from_inner(inner: Arc<Inner>) -> Self {
+        Self { inner }
+    }
+
     /// Attempts to initialize the steamworks api with the APP_ID
     /// without full API integration through SteamAPI_InitFlat
     /// and returns a client to access the rest of the api.

--- a/src/networking_sockets.rs
+++ b/src/networking_sockets.rs
@@ -1,3 +1,4 @@
+use crate::networking_types::{NetworkingConfigData, NetworkingConfigValue};
 use crate::{networking_sockets_callback, networking_types::NetConnectionRealTimeLaneStatus};
 use crate::{
     networking_types::{
@@ -5,7 +6,7 @@ use crate::{
         NetConnectionRealTimeInfo, NetworkingAvailability, NetworkingAvailabilityError,
         NetworkingConfigEntry, NetworkingIdentity, NetworkingMessage, SendFlags, SteamIpAddr,
     },
-    SteamError,
+    Client, SteamError,
 };
 use crate::{CallbackHandle, Inner, SResult};
 #[cfg(test)]
@@ -17,7 +18,10 @@ use std::sync::mpsc::Receiver;
 use std::sync::Arc;
 use sys::SteamNetworkingMessage_t;
 
-use crate::networking_types::{AppNetConnectionEnd, NetConnectionEvent};
+use crate::{
+    networking_types::{AppNetConnectionEnd, NetConnectionEvent},
+    networking_utils::NetworkingUtils,
+};
 use steamworks_sys as sys;
 
 /// Access to the steam networking sockets interface
@@ -30,6 +34,15 @@ unsafe impl Send for NetworkingSockets {}
 unsafe impl Sync for NetworkingSockets {}
 
 impl NetworkingSockets {
+    pub(crate) fn root_client(&self) -> Client {
+        Client::from_inner(self.inner.clone())
+    }
+
+    /// Utility to access `NetworkingUtils` from `NetworkingSockets` without holding a reference to Client
+    pub fn networking_utils(&self) -> NetworkingUtils {
+        self.root_client().networking_utils()
+    }
+
     /// Creates a "server" socket that listens for clients to connect to by calling ConnectByIPAddress, over ordinary UDP (IPv4 or IPv6)
     ///
     /// You must select a specific local port to listen on and set it as the port field of the local address.
@@ -434,6 +447,10 @@ pub struct ListenSocket {
 }
 
 impl ListenSocket {
+    pub(crate) fn root_client(&self) -> Client {
+        Client::from_inner(self.inner.inner.clone())
+    }
+
     pub(crate) fn new(
         handle: sys::HSteamListenSocket,
         sockets: *mut sys::ISteamNetworkingSockets,
@@ -457,6 +474,40 @@ impl ListenSocket {
             inner: inner_socket,
             _callback_handle: callback_handle,
             receiver,
+        }
+    }
+
+    /// Sets a config value for this listener, and every child `NetConnection` if applicable.
+    ///
+    /// Returns true if the setting was successfully applied.
+    ///
+    /// Every setting that is not set at the `ListenSocket` level will taken from its parents
+    /// in order, e.g. the global parameters. Alternatively, if a single `NetConnection` created from
+    /// a `ListenSocket` does not have its setting set, it will take by default the `ListenSocket` parameters.
+    pub fn set_config_value(&self, config_entry: NetworkingConfigEntry) -> bool {
+        unsafe {
+            self.root_client()
+                .networking_utils()
+                .set_config_value_internal(
+                    self.inner.handle,
+                    sys::ESteamNetworkingConfigScope::k_ESteamNetworkingConfig_ListenSocket,
+                    config_entry,
+                )
+        }
+    }
+
+    pub fn get_config_value(
+        &self,
+        value: NetworkingConfigValue,
+    ) -> Result<NetworkingConfigData, ()> {
+        unsafe {
+            self.root_client()
+                .networking_utils()
+                .get_config_value_internal(
+                    self.inner.handle,
+                    sys::ESteamNetworkingConfigScope::k_ESteamNetworkingConfig_ListenSocket,
+                    value,
+                )
         }
     }
 
@@ -644,6 +695,42 @@ impl NetConnection {
             message_buffer: Vec::new(),
             is_handled: false,
         }
+    }
+
+    /// Sets a config value for this specific net connection.
+    ///
+    /// Returns true if the setting was successfully applied.
+    /// Every setting that is not set at the `NetConnection` level will taken from its parents
+    /// in order, e.g. the listen socket, then global parameters.
+    pub fn set_config_value(&self, config_entry: NetworkingConfigEntry) -> bool {
+        unsafe {
+            self.root_client()
+                .networking_utils()
+                .set_config_value_internal(
+                    self.handle,
+                    sys::ESteamNetworkingConfigScope::k_ESteamNetworkingConfig_Connection,
+                    config_entry,
+                )
+        }
+    }
+
+    pub fn get_config_value(
+        &self,
+        value: NetworkingConfigValue,
+    ) -> Result<NetworkingConfigData, ()> {
+        unsafe {
+            self.root_client()
+                .networking_utils()
+                .get_config_value_internal(
+                    self.handle,
+                    sys::ESteamNetworkingConfigScope::k_ESteamNetworkingConfig_Connection,
+                    value,
+                )
+        }
+    }
+
+    pub(crate) fn root_client(&self) -> Client {
+        Client::from_inner(self.inner.clone())
     }
 
     pub fn info(&self) -> Result<NetConnectionInfo, InvalidHandle> {

--- a/src/networking_sockets.rs
+++ b/src/networking_sockets.rs
@@ -496,6 +496,21 @@ impl ListenSocket {
         }
     }
 
+    /// Unsets a config value for this listener.
+    ///
+    /// Returns true if the setting was successfully unset.
+    pub fn unset_config_value(&self, value: NetworkingConfigValue) -> bool {
+        unsafe {
+            self.root_client()
+                .networking_utils()
+                .unset_config_value_internal(
+                    self.inner.handle,
+                    sys::ESteamNetworkingConfigScope::k_ESteamNetworkingConfig_ListenSocket,
+                    value,
+                )
+        }
+    }
+
     /// Get a config value applied for this ListenSocket.
     pub fn get_config_value(
         &self,
@@ -711,6 +726,21 @@ impl NetConnection {
                     self.handle,
                     sys::ESteamNetworkingConfigScope::k_ESteamNetworkingConfig_Connection,
                     config_entry,
+                )
+        }
+    }
+
+    /// Unsets a config value for this specific net connection.
+    ///
+    /// Returns true if the setting was successfully unset.
+    pub fn unset_config_value(&self, value: NetworkingConfigValue) -> bool {
+        unsafe {
+            self.root_client()
+                .networking_utils()
+                .unset_config_value_internal(
+                    self.handle,
+                    sys::ESteamNetworkingConfigScope::k_ESteamNetworkingConfig_Connection,
+                    value,
                 )
         }
     }

--- a/src/networking_sockets.rs
+++ b/src/networking_sockets.rs
@@ -496,6 +496,7 @@ impl ListenSocket {
         }
     }
 
+    /// Get a config value applied for this ListenSocket.
     pub fn get_config_value(
         &self,
         value: NetworkingConfigValue,
@@ -714,6 +715,7 @@ impl NetConnection {
         }
     }
 
+    /// Get a config value applied for this NetConnection.
     pub fn get_config_value(
         &self,
         value: NetworkingConfigValue,

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1757,6 +1757,25 @@ impl NetworkingIdentity {
         }
     }
 
+    /// Tries to parse a NetworkingIdentity from a string (generated from `debug_string`)
+    ///
+    /// Returns `Err(())` if the string contained a nul-byte or was an invalid networking identity
+    pub fn from_debug_string(value: &str) -> Result<Self, ()> {
+        let c_string = CString::new(value).map_err(|_| ())?;
+        let mut inner = std::mem::MaybeUninit::<sys::SteamNetworkingIdentity>::uninit();
+        unsafe {
+            let result = sys::SteamAPI_SteamNetworkingIdentity_ParseString(
+                inner.as_mut_ptr(),
+                c_string.as_ptr()
+            );
+            if result {
+                Ok(Self { inner: inner.assume_init() })
+            } else {
+                Err(())
+            }
+        }
+    }
+
     pub fn is_equal_to(&self, other: &Self) -> bool {
         unsafe {
             sys::SteamAPI_SteamNetworkingIdentity_IsEqualTo(self.as_ptr() as *mut _, other.as_ptr())
@@ -2261,5 +2280,16 @@ mod tests {
 
             // Drop it immediately
         }
+    }
+
+    #[test]
+    #[serial]
+    fn test_networking_id_debug_ser_deser() {
+        let _client = Client::init().unwrap();
+        let steam_id = SteamId(76561199000000000u64);
+
+        let net_id1 = NetworkingIdentity::new_steam_id(steam_id);
+        let net_id2 = NetworkingIdentity::from_debug_string(&net_id1.debug_string()).unwrap();
+        assert_eq!(net_id1, net_id2);
     }
 }

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1763,6 +1763,18 @@ impl NetworkingIdentity {
         }
     }
 
+    /// Returns the underlying internal representation bytes of NetworkingIdentity
+    ///
+    /// It is properly cut by the amount of bytes necessary, e.g. steamid will only be 8 bytes, etc.
+    fn internal_representation_bytes(&self) -> &[u8] {
+        const INNER_SIZE: usize = 128;
+        let inner: &[u8; INNER_SIZE] = unsafe { std::mem::transmute(&self.inner.__bindgen_anon_1) };
+        // just to be on the safe side, take at most 128 bytes and don't trust cbSize fully.
+        // we never know what might happen on the cpp side...
+        let inner_len = std::cmp::min(self.inner.m_cbSize as usize, INNER_SIZE);
+        &inner[0..inner_len]
+    }
+
     pub(crate) fn as_ptr(&self) -> *const sys::SteamNetworkingIdentity {
         &self.inner
     }
@@ -1775,6 +1787,16 @@ impl NetworkingIdentity {
 impl PartialEq for NetworkingIdentity {
     fn eq(&self, other: &Self) -> bool {
         self.is_equal_to(other)
+    }
+}
+
+impl std::hash::Hash for NetworkingIdentity {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let e_type = self.inner.m_eType; // necessary for alignment because self.inner is 1-packed
+        e_type.hash(state);
+        let cn_size = self.inner.m_cbSize; // also necessary for alignment
+        cn_size.hash(state);
+        self.internal_representation_bytes().hash(state);
     }
 }
 

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -6,7 +6,7 @@ use crate::networking_sockets::{InnerSocket, NetConnection};
 use crate::networking_types::NetConnectionError::UnhandledType;
 use crate::{Callback, Inner, SResult, SteamId};
 use std::convert::{TryFrom, TryInto};
-use std::ffi::{c_void, CString, CStr};
+use std::ffi::{c_void, CStr, CString};
 use std::fmt::{Debug, Display, Formatter};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::panic::catch_unwind;
@@ -1753,7 +1753,7 @@ impl NetworkingIdentity {
         };
         match CStr::from_bytes_until_nul(&buffer) {
             Err(_) => String::from("invalid"),
-            Ok(cstr) => cstr.to_string_lossy().to_string()
+            Ok(cstr) => cstr.to_string_lossy().to_string(),
         }
     }
 
@@ -1766,10 +1766,12 @@ impl NetworkingIdentity {
         unsafe {
             let result = sys::SteamAPI_SteamNetworkingIdentity_ParseString(
                 inner.as_mut_ptr(),
-                c_string.as_ptr()
+                c_string.as_ptr(),
             );
             if result {
-                Ok(Self { inner: inner.assume_init() })
+                Ok(Self {
+                    inner: inner.assume_init(),
+                })
             } else {
                 Err(())
             }

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -6,7 +6,7 @@ use crate::networking_sockets::{InnerSocket, NetConnection};
 use crate::networking_types::NetConnectionError::UnhandledType;
 use crate::{Callback, Inner, SResult, SteamId};
 use std::convert::{TryFrom, TryInto};
-use std::ffi::{c_void, CString};
+use std::ffi::{c_void, CString, CStr};
 use std::fmt::{Debug, Display, Formatter};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::panic::catch_unwind;
@@ -1664,8 +1664,8 @@ pub struct NetworkingIdentity {
     inner: sys::SteamNetworkingIdentity,
 }
 
-// const NETWORK_IDENTITY_STRING_BUFFER_SIZE: usize =
-//     sys::SteamNetworkingIdentity__bindgen_ty_1::k_cchMaxString as usize;
+const NETWORK_IDENTITY_STRING_BUFFER_SIZE: usize =
+    sys::SteamNetworkingIdentity__bindgen_ty_1::k_cchMaxString as usize;
 
 impl NetworkingIdentity {
     pub fn new() -> Self {
@@ -1743,44 +1743,17 @@ impl NetworkingIdentity {
     }
 
     pub fn debug_string(&self) -> String {
-        // For some reason I can't get the original function to work,
-        // so I decided to recreate the original from https://github.com/ValveSoftware/GameNetworkingSockets/blob/529901e7c1caf50928ac8814cad205d192bbf27d/src/steamnetworkingsockets/steamnetworkingsockets_shared.cpp
-
-        // let mut buffer = vec![0i8; NETWORK_IDENTITY_STRING_BUFFER_SIZE];
-        // let string = unsafe {
-        //     sys::SteamAPI_SteamNetworkingIdentity_ToString(
-        //         self.as_ptr() as *mut sys::SteamNetworkingIdentity,
-        //         buffer.as_mut_ptr(),
-        //         NETWORK_IDENTITY_STRING_BUFFER_SIZE as u32,
-        //     );
-        //     CString::from_raw(buffer.as_mut_ptr())
-        // };
-        // string.into_string().unwrap()
-
+        let mut buffer = vec![0u8; NETWORK_IDENTITY_STRING_BUFFER_SIZE];
         unsafe {
-            match self.inner.m_eType {
-                sys::ESteamNetworkingIdentityType::k_ESteamNetworkingIdentityType_Invalid => {
-                    "invalid".to_string()
-                }
-                sys::ESteamNetworkingIdentityType::k_ESteamNetworkingIdentityType_SteamID => {
-                    let id = self.inner.__bindgen_anon_1.m_steamID64;
-                    format!("steamid:{}", id)
-                }
-                sys::ESteamNetworkingIdentityType::k_ESteamNetworkingIdentityType_IPAddress => {
-                    let ip = SteamIpAddr::from(self.inner.__bindgen_anon_1.m_ip);
-                    format!("ip:{}", ip)
-                }
-                sys::ESteamNetworkingIdentityType::k_ESteamNetworkingIdentityType_GenericString => {
-                    unimplemented!()
-                }
-                sys::ESteamNetworkingIdentityType::k_ESteamNetworkingIdentityType_GenericBytes => {
-                    unimplemented!()
-                }
-                sys::ESteamNetworkingIdentityType::k_ESteamNetworkingIdentityType_UnknownType => {
-                    unimplemented!()
-                }
-                ty => format!("bad_type:{}", ty as u32),
-            }
+            sys::SteamAPI_SteamNetworkingIdentity_ToString(
+                self.as_ptr() as *mut sys::SteamNetworkingIdentity,
+                buffer.as_mut_ptr() as *mut _ as *mut i8, // black magic to type-convert a [u8] to [i8]
+                NETWORK_IDENTITY_STRING_BUFFER_SIZE as u32,
+            );
+        };
+        match CStr::from_bytes_until_nul(&buffer) {
+            Err(_) => String::from("invalid"),
+            Ok(cstr) => cstr.to_string_lossy().to_string()
         }
     }
 

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1579,7 +1579,7 @@ pub(crate) enum NetConnectionError {
 
 #[derive(Clone)]
 pub struct NetworkingConfigEntry {
-    inner: sys::SteamNetworkingConfigValue_t,
+    pub(crate) inner: sys::SteamNetworkingConfigValue_t,
 }
 
 impl NetworkingConfigEntry {
@@ -1588,6 +1588,15 @@ impl NetworkingConfigEntry {
             m_eValue: sys::ESteamNetworkingConfigValue::k_ESteamNetworkingConfig_Invalid,
             m_eDataType: sys::ESteamNetworkingConfigDataType::k_ESteamNetworkingConfig_Int32,
             m_val: sys::SteamNetworkingConfigValue_t__bindgen_ty_1 { m_int32: 0 },
+        }
+    }
+
+    pub fn new(value_type: NetworkingConfigValue, data: NetworkingConfigData) -> Self {
+        match data {
+            NetworkingConfigData::Int32(data) => Self::new_int32(value_type, data),
+            NetworkingConfigData::Int64(data) => Self::new_int64(value_type, data),
+            NetworkingConfigData::Float(data) => Self::new_float(value_type, data),
+            NetworkingConfigData::String(data) => Self::new_string(value_type, &data),
         }
     }
 
@@ -1652,6 +1661,44 @@ impl NetworkingConfigEntry {
 impl From<NetworkingConfigEntry> for sys::SteamNetworkingConfigValue_t {
     fn from(entry: NetworkingConfigEntry) -> sys::SteamNetworkingConfigValue_t {
         entry.inner
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum NetworkingConfigData {
+    Int32(i32),
+    Int64(i64),
+    Float(f32),
+    String(String),
+}
+
+impl NetworkingConfigData {
+    pub(crate) fn from_buf(bytes: &[u8], data_type: NetworkingConfigDataType) -> Option<Self> {
+        let data = match data_type {
+            NetworkingConfigDataType::Float => {
+                let data = f32::from_ne_bytes(*bytes.get(0..4)?.as_array::<4>()?);
+                Self::Float(data)
+            }
+            NetworkingConfigDataType::Int64 => {
+                let data = i64::from_ne_bytes(*bytes.get(0..8)?.as_array::<8>()?);
+                Self::Int64(data)
+            }
+            NetworkingConfigDataType::Int32 => {
+                let data = i32::from_ne_bytes(*bytes.get(0..4)?.as_array::<4>()?);
+                Self::Int32(data)
+            }
+            NetworkingConfigDataType::String => {
+                let data = unsafe { CStr::from_ptr(bytes.as_ptr() as *const _) }
+                    .to_string_lossy()
+                    .to_string();
+                Self::String(data)
+            }
+            NetworkingConfigDataType::Callback => {
+                // TODO
+                return None;
+            }
+        };
+        Some(data)
     }
 }
 

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1700,6 +1700,39 @@ impl NetworkingConfigData {
         };
         Some(data)
     }
+
+    /// Attempts to transform this data into a `&str`. Returns `None` if the data type is not string.
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::String(s) => Some(&*s),
+            _ => None,
+        }
+    }
+
+    /// Attempts to transform this data into a `i32`. Returns `None` if the data type is not Int32.
+    pub fn as_i32(&self) -> Option<i32> {
+        match self {
+            Self::Int32(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Attempts to transform this data into a `i64`. Returns `None` if the data type is not Int64 or Int32.
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            Self::Int32(v) => Some(*v as i64),
+            Self::Int64(v) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Attempts to transform this data into a `f32`. Returns `None` if the data type is not Float.
+    pub fn as_f32(&self) -> Option<f32> {
+        match self {
+            Self::Float(v) => Some(*v),
+            _ => None,
+        }
+    }
 }
 
 /// A safe wrapper for SteamNetworkingIdentity

--- a/src/networking_types.rs
+++ b/src/networking_types.rs
@@ -1883,6 +1883,19 @@ impl NetworkingIdentity {
     pub(crate) fn as_mut_ptr(&mut self) -> *mut sys::SteamNetworkingIdentity {
         &mut self.inner
     }
+
+    /// Returns the inner struct of `NetworkingIdentity`
+    ///
+    /// In most cases should not be used, but it may be be useful
+    /// for serializing or interoping with an existing C codebase.
+    pub fn raw(&self) -> sys::SteamNetworkingIdentity {
+        self.inner.clone()
+    }
+
+    /// Allows to build a NetworkingIdentity from a raw `SteamNetworkingIdentity`
+    pub fn from_raw(raw: sys::SteamNetworkingIdentity) -> Self {
+        Self { inner: raw }
+    }
 }
 
 impl PartialEq for NetworkingIdentity {

--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -180,7 +180,7 @@ impl NetworkingUtils {
                 scope,
                 scope_handle as isize,
                 value.data_type().into(),
-                std::ptr::null()
+                std::ptr::null(),
             )
         }
     }

--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -151,6 +151,7 @@ impl NetworkingUtils {
         }
     }
 
+    /// Get a config value applied for the global instance.
     pub fn get_config_value(
         &self,
         value: NetworkingConfigValue,

--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -151,6 +151,40 @@ impl NetworkingUtils {
         }
     }
 
+    /// Unsets a config value globally, using the system defaults instead.
+    ///
+    /// Returns true if the setting was successfully unset.
+    pub fn unset_config_value(&self, value: NetworkingConfigValue) -> bool {
+        unsafe {
+            self.unset_config_value_internal(
+                0,
+                sys::ESteamNetworkingConfigScope::k_ESteamNetworkingConfig_Global,
+                value,
+            )
+        }
+    }
+
+    /// Unset a configuration value for different scopes. Internal use only.
+    ///
+    /// Returns true if the parameter was successfully unset
+    pub(crate) unsafe fn unset_config_value_internal(
+        &self,
+        scope_handle: u32,
+        scope: sys::ESteamNetworkingConfigScope,
+        value: NetworkingConfigValue,
+    ) -> bool {
+        unsafe {
+            sys::SteamAPI_ISteamNetworkingUtils_SetConfigValue(
+                self.utils,
+                value.into(),
+                scope,
+                scope_handle as isize,
+                value.data_type().into(),
+                std::ptr::null()
+            )
+        }
+    }
+
     /// Get a config value applied for the global instance.
     pub fn get_config_value(
         &self,

--- a/src/networking_utils.rs
+++ b/src/networking_utils.rs
@@ -1,4 +1,7 @@
-use crate::networking_types::{NetworkingAvailabilityResult, NetworkingMessage};
+use crate::networking_types::{
+    NetworkingAvailabilityResult, NetworkingConfigData, NetworkingConfigDataType,
+    NetworkingConfigEntry, NetworkingConfigValue, NetworkingMessage,
+};
 use crate::{register_callback, Callback, Inner};
 use std::convert::TryInto;
 use std::ffi::{c_void, CStr};
@@ -109,6 +112,105 @@ impl NetworkingUtils {
                 callback(status.status);
             });
         }
+    }
+
+    /// Set a networking configuration value globally.
+    ///
+    /// Returns true if the setting was successful.
+    pub fn set_config_value(&self, config_entry: NetworkingConfigEntry) -> bool {
+        unsafe {
+            self.set_config_value_internal(
+                0, // handle is ignored for global
+                sys::ESteamNetworkingConfigScope::k_ESteamNetworkingConfig_Global,
+                config_entry,
+            )
+        }
+    }
+
+    /// Set a configuration value for different scopes. Internal use only.
+    ///
+    /// Returns true if the parameter was successfully set
+    pub(crate) unsafe fn set_config_value_internal(
+        &self,
+        scope_handle: u32,
+        scope: sys::ESteamNetworkingConfigScope,
+        config_entry: NetworkingConfigEntry,
+    ) -> bool {
+        // FIXME: unfortunately I can't seem to make set_config_value work for strings...
+        // I can retrieve them with `get_config_value`, and it works for floats and ints, sure,
+        // but I can't edit string values specifically.
+        unsafe {
+            sys::SteamAPI_ISteamNetworkingUtils_SetConfigValue(
+                self.utils,
+                config_entry.inner.m_eValue,
+                scope,
+                scope_handle as isize,
+                config_entry.inner.m_eDataType,
+                &config_entry.inner.m_val as *const _ as *const c_void,
+            )
+        }
+    }
+
+    pub fn get_config_value(
+        &self,
+        value: NetworkingConfigValue,
+    ) -> Result<NetworkingConfigData, ()> {
+        unsafe {
+            self.get_config_value_internal(
+                0,
+                sys::ESteamNetworkingConfigScope::k_ESteamNetworkingConfig_Global,
+                value,
+            )
+        }
+    }
+
+    pub(crate) unsafe fn get_config_value_internal(
+        &self,
+        scope_handle: u32,
+        scope: sys::ESteamNetworkingConfigScope,
+        value: NetworkingConfigValue,
+    ) -> Result<NetworkingConfigData, ()> {
+        let mut buf_size = match value.data_type() {
+            NetworkingConfigDataType::String => {
+                // for strings, we need to first retrieve the size of the output string
+                let mut buf_size: usize = 0;
+                let r = sys::SteamAPI_ISteamNetworkingUtils_GetConfigValue(
+                    self.utils,
+                    value.into(),
+                    scope,
+                    scope_handle as isize,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    &mut buf_size as *mut _,
+                );
+                if r != sys::ESteamNetworkingGetConfigValueResult::k_ESteamNetworkingGetConfigValue_BufferTooSmall {
+                    // at this stage, the API *should* return BufferTooSmall
+                    return Err(());
+                }
+                buf_size
+            }
+            NetworkingConfigDataType::Int32 => std::mem::size_of::<i32>(),
+            NetworkingConfigDataType::Int64 => std::mem::size_of::<i64>(),
+            NetworkingConfigDataType::Float => std::mem::size_of::<f32>(),
+            NetworkingConfigDataType::Callback => std::mem::size_of::<*mut ()>(),
+        };
+        // once we have buf size, we can transform bytes into our values
+        let mut buf = vec![0; buf_size];
+        unsafe {
+            let r = sys::SteamAPI_ISteamNetworkingUtils_GetConfigValue(
+                self.utils,
+                value.into(),
+                scope,
+                scope_handle as isize,
+                std::ptr::null_mut(),
+                buf.as_mut_ptr() as *mut c_void,
+                &mut buf_size as *mut _,
+            );
+            if (r as i32) < 0 {
+                return Err(());
+            }
+        };
+        NetworkingConfigData::from_buf(&*buf, value.data_type()).ok_or(())
     }
 }
 


### PR DESCRIPTION
* Correct the implementation of `NetworkingIdentity::debug_string` (it was reimplemented on the rust side because implementor couldn't make it work, the fix was to not use `CString::from_raw` because that takes ownership and isntead use `CStr` which properly borrows)
* Add a `Hash` implementation for `NetworkingIdentity`
* Add `from_debug_string` which allows to parse anything generated through `debug_string` to get a NetworkingIdentity back